### PR TITLE
add XLA deterministic ops and seed global RNG for reproducibility

### DIFF
--- a/examples/haldane/train.jl
+++ b/examples/haldane/train.jl
@@ -3,10 +3,11 @@ include(joinpath(@__DIR__, "..", "..", "src", "common.jl"))
 include(joinpath(@__DIR__, "..", "..", "src", "plotting.jl"))
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    using Dates
+    using Dates, Random
     plotting = false
     n_iters = 250
     seed = 0
+    Random.seed!(seed)
     loss_png_every = 10
     grad_accum = GRAD_ACCUM_STEPS
     ode_budget = ODE_BUDGET_TRAJ

--- a/examples/monod/eval_posterior.jl
+++ b/examples/monod/eval_posterior.jl
@@ -173,6 +173,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     B                = 32
     n_substeps       = N_SUBSTEPS
     seed             = 0
+    Random.seed!(seed)
 
     # True parameters: high μ, low K — adaptive's strength
     true_μ   = 0.47f0

--- a/examples/monod/eval_spce.jl
+++ b/examples/monod/eval_spce.jl
@@ -200,6 +200,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     n_trials         = 1000
     n_substeps       = N_SUBSTEPS
     seed             = 0
+    Random.seed!(seed)
 
     # Paper-quality defaults: 5× training L,M to reduce NMC bias to O(1e-4).
     # The paired t-test cancels common bias, but absolute sPCE values benefit

--- a/examples/monod/optimize_bim.jl
+++ b/examples/monod/optimize_bim.jl
@@ -20,6 +20,7 @@ using Serialization
 
 if abspath(PROGRAM_FILE) == @__FILE__
     seed           = 0
+    Random.seed!(seed)
     n_prior_opt    = 512
     n_prior_report = 1024
     n_substeps     = N_SUBSTEPS

--- a/examples/monod/optimize_static.jl
+++ b/examples/monod/optimize_static.jl
@@ -181,6 +181,7 @@ end
 
 if abspath(PROGRAM_FILE) == @__FILE__
     seed        = 0
+    Random.seed!(seed)
     n_iters     = 1000
     n_rollouts  = 1000
     ode_budget  = ODE_BUDGET_TRAJ

--- a/examples/monod/plot_posterior.jl
+++ b/examples/monod/plot_posterior.jl
@@ -55,6 +55,7 @@ end
 if abspath(PROGRAM_FILE) == @__FILE__
     n_substeps = N_SUBSTEPS
     seed       = 0
+    Random.seed!(seed)
     N_post     = 5000
 
     results_dir = joinpath(@__DIR__, "results")

--- a/examples/monod/train.jl
+++ b/examples/monod/train.jl
@@ -3,10 +3,11 @@ include(joinpath(@__DIR__, "..", "..", "src", "common.jl"))
 include(joinpath(@__DIR__, "..", "..", "src", "plotting.jl"))
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    using Dates
+    using Dates, Random
     plotting = false
     n_iters = 1000
     seed = 0
+    Random.seed!(seed)
     loss_png_every = 10
     grad_accum = GRAD_ACCUM_STEPS
     ode_budget = ODE_BUDGET_TRAJ

--- a/examples/weibull/train.jl
+++ b/examples/weibull/train.jl
@@ -3,10 +3,11 @@ include(joinpath(@__DIR__, "..", "..", "src", "common.jl"))
 include(joinpath(@__DIR__, "..", "..", "src", "plotting.jl"))
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    using Dates
+    using Dates, Random
     plotting = false
     n_iters = 500
     seed = 0
+    Random.seed!(seed)
     loss_png_every = 10
     grad_accum = GRAD_ACCUM_STEPS
     ode_budget = ODE_BUDGET_TRAJ

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,3 +1,5 @@
+ENV["XLA_FLAGS"] = get(ENV, "XLA_FLAGS", "") * " --xla_gpu_deterministic_ops=true"
+
 # ============================================================================
 # Common definitions for DADS experiments.
 #


### PR DESCRIPTION
Set --xla_gpu_deterministic_ops=true in src/common.jl and add Random.seed!(seed) to all scripts that define a seed. Evaluation and optimization scripts now reproduce exactly; training scripts are deterministic up to IEEE 754 GPU rounding (~1 ULP).