### PR TITLE
Benchmark: JAX vs Julia/Reactant (Monod sPCE gradient step)

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,12 @@
+# Python / uv
+jax/.venv/
+**/__pycache__/
+*.pyc
+
+# Benchmark run artifacts
+logs/
+results.txt
+
+# JAX/XLA scratch
+/tmp/jax_monod_trace/
+*.hlo.txt

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,153 @@
+# JAX vs Julia/Reactant — Monod sPCE gradient-step benchmark
+
+A fair, matched-config head-to-head of the **targeted sPCE gradient step** (the
+inner loop of adaptive experimental design training) implemented two ways:
+
+- **JAX** — the `monod_jax` package from commit `3188aaa` ("Add JAX monod
+  implementation"), vendored under [`jax/`](jax/).
+- **Julia / Reactant** — the production `targeted_spce_loss` + transformer policy
+  (`common.jl`, copied from `src/`) with two interchangeable ODE integrators, plus
+  the standalone Monod model from `simplediffeq_test/`, vendored under
+  [`julia/`](julia/).
+
+Both compute the same estimator on the same model at the same `(L, M, B)`, in
+float32, and time one **loss + reverse-mode gradient** evaluation on the GPU.
+
+## Why a separate folder / fresh environment
+
+`simplediffeq_test/` pins a **dev checkout** of Reactant (`0.2.263`). This folder
+pins the **latest registered release**, `Reactant = "=0.2.273"`, so the benchmark
+doubles as a check that the production loss still compiles, differentiates, and
+trains on a released Reactant — not just a local branch.
+
+## What is being compared
+
+| | integrator / substep loop | source |
+|---|---|---|
+| Julia `hand` | hand-written RK4 inside a Reactant `@trace for` | `julia/common.jl` (production) |
+| Julia `sd` | SimpleDiffEq `SimpleRK4` `step!` inside a `@trace for` | `julia/bench.jl` |
+| JAX `scan` | RK4 substeps in `lax.scan` | `jax/monod_jax/model.py` |
+| JAX `fori` | RK4 substeps in `lax.fori_loop` | `jax/monod_jax/model.py` |
+
+The JAX package also ships a fully-`unrolled` substep loop, but it is **not**
+benchmarked here — see the asymmetry note below.
+
+Model/config identical across all rows: Monod bioreactor (state `[C_s, C_x, V]`),
+`N_STEPS=14` adaptive windows, `N_SUBSTEPS=50` RK4 substeps/window, a ~8.5k-param
+transformer policy, and the targeted sPCE estimator with `L+1` contrastive and `M`
+nuisance hypotheses.
+
+## Fairness ground rules
+
+1. **Matched `(L, M, B)`.** Default `L=255, M=256, B=512`. The JAX harness normally
+   derives `L, M` from an ODE budget; `benchmark.py` gained `--L/--M` overrides here
+   so both sides run the *exact* same shape.
+2. **Same timed region: loss + gradient only.** JAX times `value_and_grad`. Julia
+   times `single_train_step!`, which additionally applies one Adam update — but on
+   ~8.5k parameters that is a handful of elementwise ops (µs-scale, <<1% of a
+   ~200 ms step), so the two measure effectively the same thing.
+3. **Full materialization on both sides.** JAX runs with `--hyp-chunk 0 --batch-block 0`
+   (no hypothesis/batch chunking), matching Reactant materializing the full
+   `(3, L+1, B)` / `(M, B)` tensors. This is the clean apples-to-apples point; at
+   much larger `B` the two diverge by *memory strategy* (JAX chunks, Reactant
+   `@trace mincut` rematerializes), which is a different comparison.
+4. **Data prep excluded, device sync forced.** Batch sampling happens outside the
+   timer; the loss scalar is materialized inside (`Float32(l)` / `block_until_ready`)
+   so we time the whole compiled program, not an async dispatch.
+5. **Median of `NTIME`/`--n-runs` steps after warmup** (warmup absorbs compilation).
+6. **Sequential runs.** `run_all.sh` never runs two variants at once, so neither is
+   starved on the shared card. Each process is capped to `MEM_FRAC` of GPU memory.
+
+### Known minor asymmetries (documented, not corrected)
+
+- The vendored `common.jl` sets `--xla_gpu_deterministic_ops=true` (a production
+  setting for reproducible gradients); the JAX path does not force determinism.
+  Deterministic reductions can be marginally slower, so if anything this slightly
+  *disadvantages* the Julia numbers.
+- Policy weight initialization and RNG differ between the two implementations, so the
+  reported `loss=` values are sanity signals (finite, right magnitude), **not** a
+  numerical-equivalence check. Compute cost is dominated by ODE integration, which is
+  identical in structure.
+
+### Why fully-unrolled JAX is deliberately excluded
+
+JAX can fully **unroll** the substep loop; Reactant cannot. Deep unrolling blows up
+Reactant's `call_with_reactant` tracing recursion (StackOverflow / minutes-long
+compiles), so `@trace for` is its practical ceiling — there is **no Julia/Reactant
+counterpart to benchmark against**. Unrolling also does not scale on its own terms:
+its compile time explodes super-linearly with `N_SUBSTEPS` and is impractical for
+everyone by `N_SUBSTEPS≈500` (the deep-Monod regime), where all roads lead back to
+`scan`/`@trace for`. Since it is neither comparable across frameworks nor viable at
+production depth, it is left out. The honest apples-to-apples axis is **JAX
+`scan`/`fori` vs Reactant `@trace for`**, which is what this benchmark reports.
+
+## Environment
+
+- Julia 1.12.6 (`release` juliaup channel), `Reactant = "=0.2.273"` (latest release).
+- JAX `jax[cuda12]` **0.10.2** (uv-resolved; pinned in `jax/uv.lock`).
+- GPU: NVIDIA RTX 4080 SUPER (16 GB), CUDA 12. float32 throughout.
+
+## Running
+
+```bash
+# One shot: build both envs first (see below), then
+./benchmark/run_all.sh                     # matched L=255 M=256 B=512
+L=255 M=256 B=512 MEM_FRAC=0.45 ./benchmark/run_all.sh   # explicit
+
+# Environments (first time)
+julia +release --project=benchmark/julia -e 'using Pkg; Pkg.instantiate()'
+cd benchmark/jax && uv sync    # installs jax[cuda12] from the committed uv.lock
+```
+
+Individual runs:
+
+```bash
+# Julia
+INTEG=hand L=255 M=256 BMICRO=512 BACKEND=gpu \
+  julia +release --project=benchmark/julia benchmark/julia/bench.jl
+INTEG=sd   L=255 M=256 BMICRO=512 BACKEND=gpu \
+  julia +release --project=benchmark/julia benchmark/julia/bench.jl
+
+# JAX
+uv run --project=benchmark/jax python benchmark/jax/benchmark.py \
+  --L 255 --M 256 --B 512 --mode full-batch --hyp-chunk 0 --batch-block 0 \
+  --substep-loop scan     # scan | fori
+```
+
+## Results
+
+Matched config: **L=255, M=256, B=512**, `N_STEPS=14`, `N_SUBSTEPS=50`, float32,
+262,656 trajectories/step. RTX 4080 SUPER (shared, `MEM_FRAC=0.45`), Reactant
+`0.2.273`, jax `0.10.2`. Per-step = median of 20 loss+gradient evaluations after
+warmup.
+
+| implementation | substep loop | per-step (median) | compile |
+|---|---|---|---|
+| **Julia / Reactant** — SimpleDiffEq | `@trace for` + `step!` | **105.7 ms** | 205 s |
+| **Julia / Reactant** — hand-RK4 | `@trace for` | **113.5 ms** | 200 s |
+| **JAX** | `lax.scan` | 289.0 ms | **2.8 s** |
+| **JAX** | `lax.fori_loop` | 290.1 ms | **2.7 s** |
+
+Per-step distributions were tight (Julia hand 112.8–115.5 ms; sd 104.9–106.4 ms).
+
+### Findings
+
+1. **On the apples-to-apples loop axis, Reactant is ~2.7× faster per step than JAX**
+   (≈106–114 ms vs ≈289–290 ms) at this matched full-materialization config. Both
+   `lax.scan` and `lax.fori_loop` lower to an XLA `while` loop and land within 0.4%
+   of each other; Reactant's `@trace for` lowers to a tighter `while`.
+2. **hand-RK4 ≈ SimpleDiffEq** (113.5 vs 105.7 ms, ~7%; SimpleDiffEq marginally
+   faster here). XLA fuses both to equivalent HLO — the SimpleDiffEq `step!`-in-
+   `@trace for` integrator is a genuine drop-in with no runtime penalty. Both
+   produce the *identical* loss to 5 significant figures (−0.71462).
+3. **JAX compiles ~70–75× faster** (≈2.7 s vs ≈200 s). This matters for
+   dev-iteration latency; amortized over a multi-hour training run it is negligible.
+4. Absolute Reactant per-step times here (~110 ms) are ~2× faster than the earlier
+   `simplediffeq_test` measurement (~240 ms on a dev checkout) — consistent with the
+   `0.2.263`→`0.2.273` release improvements. The JAX loop numbers are comparable to
+   before (~290 vs ~310 ms), so the relative gap widened in Reactant's favour.
+
+The two loss values across frameworks (Reactant −0.71462, JAX −0.62585) differ
+because weight init and RNG differ; they are sanity signals of the same magnitude,
+not an equivalence check (compute is dominated by the identically-structured ODE
+integration).

--- a/benchmark/jax/benchmark.py
+++ b/benchmark/jax/benchmark.py
@@ -1,0 +1,219 @@
+"""Benchmark JAX Monod sPCE gradients on GPU.
+
+Defaults are chosen to match the Julia/Reactant micro-batch benchmark:
+`B_multiplier=8`, `grad_accum=1`, and `mode=full-batch`.
+"""
+
+import argparse
+import functools
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from monod_jax.batched import blocked_batched_spce_loss
+from monod_jax.model import allocate_budget
+from monod_jax.policy import init_params
+from monod_jax.training import batch_loss
+
+
+def main():
+    parser = argparse.ArgumentParser(description="JAX Monod sPCE GPU benchmark")
+    parser.add_argument("--B", type=int, default=0, help="Micro-batch size (0=auto)")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=("full-batch", "legacy-chunked"),
+        default="full-batch",
+        help="Execution mode",
+    )
+    parser.add_argument(
+        "--chunk",
+        "--episode-chunk",
+        dest="episode_chunk",
+        type=int,
+        default=128,
+        help="Episode vmap chunk size for legacy-chunked mode (0=full vmap)",
+    )
+    parser.add_argument(
+        "--hyp-chunk",
+        type=int,
+        default=32,
+        help="Hypothesis chunk size for full-batch mode (0=materialize full H)",
+    )
+    parser.add_argument(
+        "--batch-block",
+        type=int,
+        default=1024,
+        help="Outer batch block size for full-batch mode (0=single full-B block)",
+    )
+    parser.add_argument(
+        "--substep-loop",
+        type=str,
+        choices=("unrolled", "scan", "fori"),
+        default="unrolled",
+        help="RK4 substep loop implementation",
+    )
+    parser.add_argument("--budget", type=int, default=6_250_000, help="ODE trajectory budget")
+    parser.add_argument(
+        "--B-multiplier",
+        type=int,
+        default=8,
+        help="B_multiplier for budget allocation (Julia/Reactant micro-batch uses 8)",
+    )
+    parser.add_argument(
+        "--grad-accum",
+        type=int,
+        default=1,
+        help="Gradient accumulation steps (each over B_micro)",
+    )
+    parser.add_argument("--n-runs", type=int, default=20, help="Timed gradient evaluations")
+    parser.add_argument("--n-warmup", type=int, default=2, help="Warmup runs (incl. compile)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--L",
+        type=int,
+        default=0,
+        help="Override contrastive sample count L (0=derive from --budget). "
+        "Use with --M and --B to exactly match the Julia/Reactant config.",
+    )
+    parser.add_argument(
+        "--M",
+        type=int,
+        default=0,
+        help="Override nuisance sample count M (0=derive from --budget).",
+    )
+    args = parser.parse_args()
+
+    L, M, B_auto = allocate_budget(args.budget, B_multiplier=args.B_multiplier)
+    if args.L > 0:
+        L = args.L
+    if args.M > 0:
+        M = args.M
+    B_micro = args.B if args.B > 0 else B_auto
+    if args.mode == "legacy-chunked" and args.episode_chunk > 0:
+        B_micro = (B_micro // args.episode_chunk) * args.episode_chunk
+    grad_accum = args.grad_accum
+    B_total = B_micro * grad_accum
+    traj_per_step = B_total * (L + 2 + M)
+
+    print(f"Device: {jax.devices()[0]}")
+    print(f"B_micro={B_micro}, B_total={B_total}, grad_accum={grad_accum}")
+    if args.mode == "full-batch":
+        print(
+            f"hyp_chunk_size={args.hyp_chunk}, "
+            f"batch_block_size={args.batch_block}, "
+            f"substep_loop={args.substep_loop}"
+        )
+    else:
+        effective_chunk = args.episode_chunk if args.episode_chunk > 0 else B_micro
+        print(
+            f"episode_chunk_size={effective_chunk}, "
+            f"n_chunks={B_micro // effective_chunk}, "
+            f"substep_loop={args.substep_loop}"
+        )
+    print(f"L={L}, M={M}")
+    print(f"Trajectories per grad step: {traj_per_step:,}")
+    print()
+
+    key = jax.random.key(args.seed)
+    key, init_key = jax.random.split(key)
+    params = init_params(init_key)
+    n_params = sum(x.size for x in jax.tree.leaves(params))
+    print(f"Parameters: {n_params:,}")
+
+    @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5, 6))
+    def grad_step_full_batch(
+        params, keys, L, M, hyp_chunk_size, batch_block_size, substep_loop
+    ):
+        return jax.value_and_grad(blocked_batched_spce_loss)(
+            params, keys, L, M, hyp_chunk_size, batch_block_size, substep_loop
+        )
+
+    @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5))
+    def grad_step_legacy(params, keys, L, M, episode_chunk_size, substep_loop):
+        return jax.value_and_grad(batch_loss)(
+            params, keys, L, M, episode_chunk_size, substep_loop
+        )
+
+    def run_one_step(params, key):
+        total_loss = 0.0
+        acc_grads = None
+        for _ in range(grad_accum):
+            key, sk = jax.random.split(key)
+            keys = jax.random.split(sk, B_micro)
+            if args.mode == "full-batch":
+                loss, grads = grad_step_full_batch(
+                    params,
+                    keys,
+                    L,
+                    M,
+                    args.hyp_chunk,
+                    args.batch_block,
+                    args.substep_loop,
+                )
+            else:
+                loss, grads = grad_step_legacy(
+                    params, keys, L, M, args.episode_chunk, args.substep_loop
+                )
+            total_loss += float(loss)
+            if acc_grads is None:
+                acc_grads = grads
+            else:
+                acc_grads = jax.tree.map(jnp.add, acc_grads, grads)
+        jax.block_until_ready(acc_grads)
+        return key, total_loss / grad_accum
+
+    print("Compiling...", flush=True)
+    t_compile_start = time.perf_counter()
+    for i in range(args.n_warmup):
+        key, avg_loss = run_one_step(params, key)
+        if i == 0:
+            t_compile = time.perf_counter() - t_compile_start
+            print(f"First call (compile): {t_compile:.1f}s, loss={avg_loss:.6f}")
+
+    print(f"\nBenchmarking {args.n_runs} gradient evaluations...")
+    times = []
+    for _ in range(args.n_runs):
+        t0 = time.perf_counter()
+        key, avg_loss = run_one_step(params, key)
+        times.append(time.perf_counter() - t0)
+
+    times = np.array(times)
+    median_ms = np.median(times) * 1000
+    mean_ms = np.mean(times) * 1000
+    traj_per_sec = traj_per_step / np.median(times)
+
+    print(f"\n{'=' * 60}")
+    print("JAX GPU Benchmark — Monod Bioreactor sPCE")
+    print(f"{'=' * 60}")
+    if args.mode == "full-batch":
+        mode = (
+            f"full-batch (hyp_chunk={args.hyp_chunk}, "
+            f"batch_block={args.batch_block}, "
+            f"substep_loop={args.substep_loop})"
+        )
+    else:
+        mode = (
+            f"legacy-chunked (episode_chunk={args.episode_chunk}, "
+            f"substep_loop={args.substep_loop})"
+        )
+    print(f"  B_micro={B_micro}, B_total={B_total}, grad_accum={grad_accum}")
+    print(f"  mode={mode}, L={L}, M={M}")
+    print(f"  Trajectories/step:  {traj_per_step:>12,}")
+    print(f"  Parameters:         {n_params:>12,}")
+    print(f"  Grad step:          {median_ms:>10.2f} ms (median), {mean_ms:.2f} ms (mean)")
+    print(f"  Throughput:         {traj_per_sec:>12,.0f} trajectories/s")
+    print(f"  Compile:            {t_compile:>10.1f} s")
+    print(f"{'=' * 60}")
+    # Machine-parseable summary line (mirrors the Julia harness) for run_all.sh.
+    print(
+        f"RESULT jax substep={args.substep_loop} L={L} M={M} B={B_micro} "
+        f"median_ms={median_ms:.2f} compile_s={t_compile:.1f} loss={avg_loss:.6f}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/jax/check_equivalence.py
+++ b/benchmark/jax/check_equivalence.py
@@ -1,0 +1,115 @@
+"""Compare the legacy and full-batch JAX losses on fixed inputs."""
+
+import argparse
+
+import jax
+import jax.numpy as jnp
+
+from monod_jax.batched import batched_spce_loss
+from monod_jax.policy import init_params
+from monod_jax.training import batch_loss
+
+
+def _tree_max_abs(tree):
+    leaves = jax.tree.leaves(tree)
+    return max(float(jnp.nanmax(jnp.abs(x))) for x in leaves)
+
+
+def _tree_max_abs_diff(tree_a, tree_b):
+    diffs = jax.tree.map(lambda a, b: jnp.nanmax(jnp.abs(a - b)), tree_a, tree_b)
+    return max(float(x) for x in jax.tree.leaves(diffs))
+
+
+def _tree_max_rel_diff(tree_a, tree_b, eps):
+    rel = jax.tree.map(
+        lambda a, b: jnp.max(
+            jnp.nan_to_num(jnp.abs(a - b), nan=jnp.inf)
+            / jnp.maximum(jnp.maximum(jnp.abs(a), jnp.abs(b)), eps)
+        ),
+        tree_a,
+        tree_b,
+    )
+    return max(float(x) for x in jax.tree.leaves(rel))
+
+
+def _tree_has_nan(tree):
+    return any(bool(jnp.isnan(x).any()) for x in jax.tree.leaves(tree))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check JAX loss/gradient equivalence")
+    parser.add_argument("--B", type=int, default=64, help="Episode batch size")
+    parser.add_argument("--L", type=int, default=8, help="Contrastive samples")
+    parser.add_argument("--M", type=int, default=8, help="Nuisance samples")
+    parser.add_argument(
+        "--episode-chunk",
+        type=int,
+        default=16,
+        help="Legacy episode chunk size",
+    )
+    parser.add_argument(
+        "--hyp-chunk",
+        type=int,
+        default=4,
+        help="Full-batch hypothesis chunk size",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--atol", type=float, default=3e-4)
+    parser.add_argument("--rtol", type=float, default=1e-3)
+    args = parser.parse_args()
+
+    key = jax.random.key(args.seed)
+    key, init_key, batch_key = jax.random.split(key, 3)
+    params = init_params(init_key)
+    keys = jax.random.split(batch_key, args.B)
+
+    legacy_fn = jax.jit(jax.value_and_grad(batch_loss), static_argnums=(2, 3, 4))
+    full_fn = jax.jit(
+        jax.value_and_grad(batched_spce_loss), static_argnums=(2, 3, 4)
+    )
+
+    legacy_loss, legacy_grads = legacy_fn(
+        params, keys, args.L, args.M, args.episode_chunk
+    )
+    full_loss, full_grads = full_fn(params, keys, args.L, args.M, args.hyp_chunk)
+
+    legacy_loss, full_loss, legacy_grads, full_grads = jax.tree.map(
+        jax.block_until_ready,
+        (legacy_loss, full_loss, legacy_grads, full_grads),
+    )
+
+    loss_abs = float(jnp.abs(legacy_loss - full_loss))
+    loss_rel = float(
+        loss_abs / max(abs(float(legacy_loss)), abs(float(full_loss)), 1e-8)
+    )
+    grad_abs = _tree_max_abs_diff(legacy_grads, full_grads)
+    grad_rel = _tree_max_rel_diff(legacy_grads, full_grads, 1e-8)
+    grad_scale = max(_tree_max_abs(legacy_grads), _tree_max_abs(full_grads), 1e-8)
+    legacy_has_nan = _tree_has_nan(legacy_grads)
+    full_has_nan = _tree_has_nan(full_grads)
+
+    print("=== JAX Equivalence Check ===")
+    print(f"B={args.B}, L={args.L}, M={args.M}")
+    print(
+        f"legacy episode_chunk={args.episode_chunk}, "
+        f"full-batch hyp_chunk={args.hyp_chunk}"
+    )
+    print(f"loss legacy={float(legacy_loss):.8f}, full_batch={float(full_loss):.8f}")
+    print(f"loss abs diff={loss_abs:.3e}, rel diff={loss_rel:.3e}")
+    print(f"legacy grad has_nan={legacy_has_nan}, full grad has_nan={full_has_nan}")
+    print(f"grad max abs diff={grad_abs:.3e}")
+    print(f"grad max rel diff={grad_rel:.3e}")
+    print(f"grad scale={grad_scale:.3e}")
+
+    if loss_abs > args.atol and loss_rel > args.rtol:
+        raise SystemExit("Loss equivalence check failed.")
+    if legacy_has_nan or full_has_nan:
+        raise SystemExit("Gradient equivalence check failed: NaNs detected.")
+    if grad_abs > args.atol and grad_rel > args.rtol:
+        raise SystemExit("Gradient equivalence check failed.")
+
+    print("Equivalence check passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/jax/monod_jax/__init__.py
+++ b/benchmark/jax/monod_jax/__init__.py
@@ -1,0 +1,17 @@
+"""JAX implementation of Monod bioreactor adaptive sPCE design."""
+
+from .model import (
+    N_STEPS,
+    DT,
+    N_SUBSTEPS,
+    ACTION_HI,
+    dynamics,
+    rk4_step,
+    integrate,
+    sample_theta_full,
+    sample_theta_obs,
+    allocate_budget,
+)
+from .batched import batched_spce_loss, blocked_batched_spce_loss
+from .policy import init_params, policy_forward
+from .training import single_episode_loss, batch_loss, train  # noqa: F401

--- a/benchmark/jax/monod_jax/batched.py
+++ b/benchmark/jax/monod_jax/batched.py
@@ -1,0 +1,323 @@
+"""Batch-first targeted sPCE loss.
+
+Keeps the outer Monte Carlo batch `B` fully batched, while chunking the
+hypothesis axes `(L+1)` and `M` to control memory. This matches the paper's
+estimator structure without materializing the full `(B, H, ...)` recurrence
+state that OOMs on a 3080.
+"""
+
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+
+from .model import (
+    N_STEPS,
+    CS0,
+    V0,
+    get_integrator,
+    sample_theta_full,
+    sample_theta_obs,
+)
+from .policy import PE, ACTION_HI, D_MODEL, N_HEADS, HEAD_DIM
+
+
+# ============================================================================
+#  Batched policy forward: (B, N_STEPS, 2) -> (B,)
+# ============================================================================
+
+
+def _rms_norm_batched(x, scale):
+    """RMSNorm over last dim. x: (B, seq, D)."""
+    return x / jnp.sqrt(jnp.mean(x**2, axis=-1, keepdims=True) + 1e-6) * scale
+
+
+def _mha_batched(x, p):
+    """Multi-head self-attention. x: (B, S, D)."""
+    B, S, _ = x.shape
+    q = (x @ p["q"].T).reshape(B, S, N_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+    k = (x @ p["k"].T).reshape(B, S, N_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+    v = (x @ p["v"].T).reshape(B, S, N_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+    w = jax.nn.softmax(
+        q @ jnp.swapaxes(k, -2, -1) / jnp.sqrt(jnp.float32(HEAD_DIM)), axis=-1
+    )
+    o = (w @ v).transpose(0, 2, 1, 3).reshape(B, S, D_MODEL)
+    return o @ p["out_w"].T + p["out_b"]
+
+
+def policy_forward_batched(params, buf):
+    """Batched transformer policy. buf: (B, N_STEPS, 2) -> (B,) actions."""
+    x = buf @ params["input_proj"]["weight"].T + params["input_proj"]["bias"] + PE
+    x = x + _mha_batched(_rms_norm_batched(x, params["rms1"]["scale"]), params["mha"])
+    h = _rms_norm_batched(x, params["rms2"]["scale"])
+    ff = jax.nn.gelu(h @ params["ff"]["w1"].T + params["ff"]["b1"])
+    x = x + ff @ params["ff"]["w2"].T + params["ff"]["b2"]
+    logit = x[:, -1, :] @ params["out"]["w"].T + params["out"]["b"]
+    return ACTION_HI * jax.nn.sigmoid(logit[:, 0])
+
+
+# ============================================================================
+#  Batched rollout over the true episode batch
+# ============================================================================
+
+
+def _rollout_batched(
+    params, theta_dyn_true, sigma_true, Cx0_true, epsilon, substep_loop="unrolled"
+):
+    """Generate one adaptive trajectory per episode.
+
+    Returns step-major arrays `(N_STEPS, B)` to match `lax.scan` directly and
+    avoid transposing observations/designs before likelihood evaluation.
+    """
+    integrate_fn = get_integrator(substep_loop)
+    B = theta_dyn_true.shape[0]
+    dtype = theta_dyn_true.dtype
+    u0 = jnp.stack([
+        jnp.full((B,), CS0, dtype=dtype),
+        Cx0_true,
+        jnp.full((B,), V0, dtype=dtype),
+    ], axis=-1)
+    input_buffer0 = jnp.zeros((B, N_STEPS, 2), dtype=dtype)
+
+    def adaptive_step(carry, step_idx):
+        u, input_buffer = carry
+        action = policy_forward_batched(params, input_buffer)
+        u = integrate_fn(u, theta_dyn_true, action)
+        y_obs = u[..., 0] + sigma_true * epsilon[:, step_idx]
+        input_buffer = input_buffer.at[:, step_idx, 0].set(y_obs)
+        input_buffer = input_buffer.at[:, step_idx, 1].set(action)
+        return (u, input_buffer), (y_obs, action)
+
+    (_, _), (observations_t, designs_t) = jax.lax.scan(
+        adaptive_step, (u0, input_buffer0), jnp.arange(N_STEPS)
+    )
+    return observations_t, designs_t
+
+
+# ============================================================================
+#  Chunked log-likelihood reductions over hypothesis axes
+# ============================================================================
+
+
+def _scan_loglik_chunk(
+    observations_t,
+    designs_t,
+    theta_dyn_chunk,
+    theta_obs_chunk,
+    substep_loop="unrolled",
+):
+    """Log-likelihood for one hypothesis chunk across all B episodes.
+
+    Args:
+        observations_t: (N_STEPS, B)
+        designs_t: (N_STEPS, B)
+        theta_dyn_chunk: (B, Hc, 2)
+        theta_obs_chunk: (B, Hc, 2)
+    Returns:
+        (B, Hc) array of per-hypothesis log-likelihoods.
+    """
+    integrate_fn = get_integrator(substep_loop)
+    B, Hc = theta_obs_chunk.shape[:2]
+    dtype = theta_obs_chunk.dtype
+    u0 = jnp.stack([
+        jnp.full((B, Hc), CS0, dtype=dtype),
+        theta_obs_chunk[..., 1],
+        jnp.full((B, Hc), V0, dtype=dtype),
+    ], axis=-1).reshape(B * Hc, 3)
+    theta_dyn_flat = theta_dyn_chunk.reshape(B * Hc, 2)
+    sigma_sq = theta_obs_chunk[..., 0] ** 2
+    ll0 = jnp.zeros((B, Hc), dtype=dtype)
+
+    def step_fn(carry, step_inputs):
+        u_flat, ll = carry
+        obs_t, design_t = step_inputs
+        design = jnp.broadcast_to(design_t[:, None], sigma_sq.shape).reshape(B * Hc)
+        u_flat = integrate_fn(u_flat, theta_dyn_flat, design)
+        residual = obs_t[:, None] - u_flat[:, 0].reshape(B, Hc)
+        ll = ll - 0.5 * (residual**2 / sigma_sq + jnp.log(sigma_sq))
+        return (u_flat, ll), None
+
+    (_, ll_total), _ = jax.lax.scan(
+        step_fn, (u0, ll0), (observations_t, designs_t)
+    )
+    return ll_total
+
+
+def _chunked_logmeanexp(
+    observations_t,
+    designs_t,
+    theta_dyn,
+    theta_obs,
+    n_valid,
+    chunk_size,
+    substep_loop="unrolled",
+):
+    """Compute `log(mean(exp(ll)))` over a hypothesis axis without materializing it."""
+    H = theta_dyn.shape[1]
+    dtype = theta_dyn.dtype
+    if chunk_size <= 0 or chunk_size >= H:
+        ll = _scan_loglik_chunk(
+            observations_t, designs_t, theta_dyn, theta_obs, substep_loop
+        )
+        return jax.scipy.special.logsumexp(ll, axis=1) - jnp.log(
+            jnp.asarray(n_valid, dtype=dtype)
+        )
+
+    n_chunks = math.ceil(H / chunk_size)
+    padded_H = n_chunks * chunk_size
+    if padded_H != H:
+        pad = padded_H - H
+        pad_dyn = jnp.repeat(theta_dyn[:, :1, :], pad, axis=1)
+        pad_obs = jnp.repeat(theta_obs[:, :1, :], pad, axis=1)
+        theta_dyn = jnp.concatenate([theta_dyn, pad_dyn], axis=1)
+        theta_obs = jnp.concatenate([theta_obs, pad_obs], axis=1)
+
+    B = theta_dyn.shape[0]
+    theta_dyn_chunks = jnp.swapaxes(
+        theta_dyn.reshape(B, n_chunks, chunk_size, 2), 0, 1
+    )
+    theta_obs_chunks = jnp.swapaxes(
+        theta_obs.reshape(B, n_chunks, chunk_size, 2), 0, 1
+    )
+    valid_mask = (jnp.arange(padded_H) < n_valid).reshape(n_chunks, chunk_size)
+
+    def scan_chunk(logsumexp_acc, inputs):
+        theta_dyn_chunk, theta_obs_chunk, mask_chunk = inputs
+        ll_chunk = _scan_loglik_chunk(
+            observations_t,
+            designs_t,
+            theta_dyn_chunk,
+            theta_obs_chunk,
+            substep_loop,
+        )
+        ll_chunk = jnp.where(mask_chunk[None, :], ll_chunk, -jnp.inf)
+        chunk_lse = jax.scipy.special.logsumexp(ll_chunk, axis=1)
+        return jnp.logaddexp(logsumexp_acc, chunk_lse), None
+
+    init = jnp.full((B,), -jnp.inf, dtype=dtype)
+    logsumexp_total, _ = jax.lax.scan(
+        scan_chunk, init, (theta_dyn_chunks, theta_obs_chunks, valid_mask)
+    )
+    return logsumexp_total - jnp.log(jnp.asarray(n_valid, dtype=dtype))
+
+
+# ============================================================================
+#  Batched sPCE loss over B episodes
+# ============================================================================
+
+
+def _batched_spce_loss_per_episode(
+    params, keys, L, M, hypothesis_chunk_size=32, substep_loop="unrolled"
+):
+    """Per-episode targeted sPCE loss with full outer batch semantics.
+
+    Args:
+        params: policy parameter pytree
+        keys: (B,) PRNG keys
+        L, M: contrastive / nuisance sample counts
+        hypothesis_chunk_size: chunk size for `(L+1)` and `M` axes. Set to 0 to
+            materialize the full hypothesis axis at once.
+    Returns:
+        (B,) loss values
+    """
+    B = keys.shape[0]
+    n_denom = L + 1
+
+    k_all = jax.vmap(lambda k: jax.random.split(k, 3))(keys)
+    k_theta = k_all[:, 0]
+    k_obs_numer = k_all[:, 1]
+    k_noise = k_all[:, 2]
+
+    theta_full = jax.vmap(sample_theta_full, in_axes=(0, None))(k_theta, n_denom)
+
+    theta_dyn_true = theta_full[:, 0, :2]
+    sigma_true = theta_full[:, 0, 2]
+    Cx0_true = theta_full[:, 0, 3]
+
+    epsilon = jax.vmap(lambda k: jax.random.normal(k, (N_STEPS,)))(k_noise)
+    observations_t, designs_t = _rollout_batched(
+        params, theta_dyn_true, sigma_true, Cx0_true, epsilon, substep_loop
+    )
+
+    theta_dyn_denom = theta_full[:, :, :2]
+    theta_obs_denom = theta_full[:, :, 2:]
+    log_den = _chunked_logmeanexp(
+        observations_t,
+        designs_t,
+        theta_dyn_denom,
+        theta_obs_denom,
+        n_denom,
+        hypothesis_chunk_size,
+        substep_loop,
+    )
+
+    theta_obs_numer = jax.vmap(sample_theta_obs, in_axes=(0, None))(k_obs_numer, M)
+    theta_dyn_numer = jnp.broadcast_to(theta_dyn_true[:, None, :], (B, M, 2))
+    log_num = _chunked_logmeanexp(
+        observations_t,
+        designs_t,
+        theta_dyn_numer,
+        theta_obs_numer,
+        M,
+        hypothesis_chunk_size,
+        substep_loop,
+    )
+
+    return -(log_num - log_den)
+
+
+def batched_spce_loss(params, keys, L, M, hypothesis_chunk_size=32, substep_loop="unrolled"):
+    """Mean targeted sPCE loss over a fully batched key array."""
+    return jnp.mean(
+        _batched_spce_loss_per_episode(
+            params, keys, L, M, hypothesis_chunk_size, substep_loop
+        )
+    )
+
+
+def blocked_batched_spce_loss(
+    params,
+    keys,
+    L,
+    M,
+    hypothesis_chunk_size=32,
+    batch_block_size=0,
+    substep_loop="unrolled",
+):
+    """Batch-first loss with optional blocking over the outer Monte Carlo axis.
+
+    Blocking keeps the semantics of a batched outer expectation while avoiding
+    the pathological compile/runtime behavior of both tiny per-episode chunks
+    and a single monolithic `B=6706` block.
+    """
+    B = keys.shape[0]
+    if batch_block_size <= 0 or batch_block_size >= B:
+        return batched_spce_loss(
+            params, keys, L, M, hypothesis_chunk_size, substep_loop
+        )
+
+    n_blocks = math.ceil(B / batch_block_size)
+    padded_B = n_blocks * batch_block_size
+    if padded_B != B:
+        pad = padded_B - B
+        keys = jnp.concatenate([keys, keys[:pad]], axis=0)
+    key_blocks = keys.reshape(n_blocks, batch_block_size, *keys.shape[1:])
+    valid_mask = (jnp.arange(padded_B) < B).reshape(n_blocks, batch_block_size)
+
+    def scan_block(total_loss, block_inputs):
+        block_keys, block_mask = block_inputs
+        loss_per_episode = _batched_spce_loss_per_episode(
+            params, block_keys, L, M, hypothesis_chunk_size, substep_loop
+        )
+        total_loss = total_loss + jnp.sum(
+            jnp.where(block_mask, loss_per_episode, 0.0)
+        )
+        return total_loss, None
+
+    total_loss, _ = jax.lax.scan(
+        scan_block,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        (key_blocks, valid_mask),
+    )
+    return total_loss / jnp.asarray(B, dtype=jnp.float32)

--- a/benchmark/jax/monod_jax/model.py
+++ b/benchmark/jax/monod_jax/model.py
@@ -1,0 +1,160 @@
+"""Monod bioreactor: dynamics, RK4 integration, prior sampling, budget allocation."""
+
+import jax
+import jax.numpy as jnp
+
+# ============================================================================
+#  Constants (match Julia model.jl exactly)
+# ============================================================================
+
+N_STEPS = 14
+DT = 1.0
+N_SUBSTEPS = 50
+ACTION_HI = 10.0
+
+# Prior bounds (uniform)
+MU_MAX_LO, MU_MAX_HI = 0.3, 0.5
+K_S_LO, K_S_HI = 0.3, 0.6
+SIGMA_LO, SIGMA_HI = 0.05, 0.15
+CX0_LO, CX0_HI = 0.10, 0.50
+
+# Initial conditions
+CS0 = 3.0
+V0 = 7.0
+
+# ============================================================================
+#  Monod bioreactor dynamics
+# ============================================================================
+
+
+def dynamics(u, theta_dyn, Q_in):
+    """Monod bioreactor ODE RHS.
+
+    Supports both scalar states `(3,)` and batched states `(..., 3)`.
+    """
+    C_s, C_x, V = u[..., 0], u[..., 1], u[..., 2]
+    mu_max, K_s = theta_dyn[..., 0], theta_dyn[..., 1]
+    mu = mu_max * C_s / (K_s + C_s)
+    sigma = mu / 0.777
+    dC_s = -sigma * C_x + (Q_in / V) * (50.0 - C_s)
+    dC_x = mu * C_x - (Q_in / V) * C_x
+    dV = Q_in + jnp.zeros_like(V)
+    return jnp.stack([dC_s, dC_x, dV], axis=-1)
+
+
+# ============================================================================
+#  RK4 integrator
+# ============================================================================
+
+
+def rk4_step(u, theta_dyn, Q_in, dt):
+    """Single RK4 step."""
+    k1 = dynamics(u, theta_dyn, Q_in)
+    k2 = dynamics(u + 0.5 * dt * k1, theta_dyn, Q_in)
+    k3 = dynamics(u + 0.5 * dt * k2, theta_dyn, Q_in)
+    k4 = dynamics(u + dt * k3, theta_dyn, Q_in)
+    return u + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+
+
+@jax.checkpoint
+def integrate_unrolled(u, theta_dyn, Q_in):
+    """Integrate one macro time step (DT) with unrolled RK4 substeps."""
+    dt_sub = DT / N_SUBSTEPS
+    for _ in range(N_SUBSTEPS):
+        u = rk4_step(u, theta_dyn, Q_in, dt_sub)
+    return u
+
+
+@jax.checkpoint
+def integrate_scan(u, theta_dyn, Q_in):
+    """Integrate one macro time step with RK4 substeps in a `lax.scan`."""
+    dt_sub = DT / N_SUBSTEPS
+
+    def body_fn(state, _):
+        return rk4_step(state, theta_dyn, Q_in, dt_sub), None
+
+    u, _ = jax.lax.scan(body_fn, u, None, length=N_SUBSTEPS)
+    return u
+
+
+@jax.checkpoint
+def integrate_fori(u, theta_dyn, Q_in):
+    """Integrate one macro time step with RK4 substeps in a `lax.fori_loop`."""
+    dt_sub = DT / N_SUBSTEPS
+
+    def body_fn(_, state):
+        return rk4_step(state, theta_dyn, Q_in, dt_sub)
+
+    return jax.lax.fori_loop(0, N_SUBSTEPS, body_fn, u)
+
+
+def get_integrator(substep_loop):
+    """Select the RK4 substep loop implementation."""
+    if substep_loop == "unrolled":
+        return integrate_unrolled
+    if substep_loop == "scan":
+        return integrate_scan
+    if substep_loop == "fori":
+        return integrate_fori
+    raise ValueError(f"Unsupported substep_loop={substep_loop!r}")
+
+
+def integrate(u, theta_dyn, Q_in):
+    """Default integrator used by the baseline path."""
+    return integrate_unrolled(u, theta_dyn, Q_in)
+
+
+# ============================================================================
+#  Prior sampling
+# ============================================================================
+
+
+def sample_theta_full(key, n):
+    """Sample n full parameter sets from uniform prior.
+
+    Returns: (n, 4) with columns [mu_max, K_s, sigma, Cx0].
+    """
+    u = jax.random.uniform(key, (n, 4))
+    lo = jnp.array([MU_MAX_LO, K_S_LO, SIGMA_LO, CX0_LO])
+    hi = jnp.array([MU_MAX_HI, K_S_HI, SIGMA_HI, CX0_HI])
+    return lo + (hi - lo) * u
+
+
+def sample_theta_obs(key, n):
+    """Sample n observation parameter sets [sigma, Cx0] from uniform prior."""
+    u = jax.random.uniform(key, (n, 2))
+    lo = jnp.array([SIGMA_LO, CX0_LO])
+    hi = jnp.array([SIGMA_HI, CX0_HI])
+    return lo + (hi - lo) * u
+
+
+# ============================================================================
+#  Budget allocation (port of src/utils.jl)
+# ============================================================================
+
+
+def allocate_budget(C, lambda_L=1.0, lambda_M=1.0, B_multiplier=1):
+    """Jointly optimize L (contrastive), M (nuisance), B (batch) for budget C.
+
+    Minimizes 1/(B*B_multiplier) + lambda_L/(L+1)^2 + lambda_M/M^2
+    subject to B = C // (L + 2 + M).
+    """
+    L_seed = max(1, round((2 * lambda_L * C * B_multiplier) ** (1 / 3)) - 1)
+    M_seed = max(1, round((2 * lambda_M * C * B_multiplier) ** (1 / 3)))
+    w = max(20, L_seed // 3)
+    best_L, best_M, best_B, best_obj = (
+        L_seed, M_seed, C // (L_seed + 2 + M_seed), float("inf"),
+    )
+    for L in range(max(1, L_seed - w), L_seed + w + 1):
+        for M in range(max(1, M_seed - w), M_seed + w + 1):
+            B = C // (L + 2 + M)
+            if B < 1:
+                break
+            obj = (
+                1.0 / (B * B_multiplier)
+                + lambda_L / (L + 1) ** 2
+                + lambda_M / M ** 2
+            )
+            if obj < best_obj:
+                best_obj, best_L, best_M, best_B = obj, L, M, B
+    return best_L, best_M, best_B

--- a/benchmark/jax/monod_jax/policy.py
+++ b/benchmark/jax/monod_jax/policy.py
@@ -1,0 +1,135 @@
+"""Transformer policy for Monod bioreactor (pure JAX, no Flax/Equinox)."""
+
+import jax
+import jax.numpy as jnp
+
+from .model import N_STEPS, ACTION_HI
+
+# ============================================================================
+#  Architecture constants
+# ============================================================================
+
+D_MODEL = 32
+N_HEADS = 4
+HEAD_DIM = D_MODEL // N_HEADS  # 8
+D_FF = 64
+
+# ============================================================================
+#  Sinusoidal positional encoding (precomputed)
+# ============================================================================
+
+
+def _sinusoidal_pe():
+    """Positional encoding matching common_core.jl:39-47.
+
+    Returns (N_STEPS, D_MODEL) array with interleaved sin/cos.
+    """
+    pos = jnp.arange(N_STEPS, dtype=jnp.float32)
+    div = jnp.exp(
+        jnp.arange(0, D_MODEL, 2, dtype=jnp.float32) * -(jnp.log(1000.0) / D_MODEL)
+    )
+    angles = jnp.outer(pos, div)  # (N_STEPS, D_MODEL//2)
+    pe = jnp.zeros((N_STEPS, D_MODEL), dtype=jnp.float32)
+    pe = pe.at[:, 0::2].set(jnp.sin(angles))
+    pe = pe.at[:, 1::2].set(jnp.cos(angles))
+    return pe
+
+
+PE = _sinusoidal_pe()
+
+# ============================================================================
+#  Parameter initialization
+# ============================================================================
+
+
+def _glorot(key, shape):
+    """Glorot uniform initialization."""
+    fan_in, fan_out = shape[-1], shape[-2] if len(shape) > 1 else shape[-1]
+    lim = jnp.sqrt(6.0 / (fan_in + fan_out))
+    return jax.random.uniform(key, shape, minval=-lim, maxval=lim)
+
+
+def init_params(key):
+    """Initialize transformer policy parameters.
+
+    Returns a nested dict (pytree) matching the Lux architecture in model.jl:166-182.
+    """
+    k = jax.random.split(key, 8)
+    return {
+        "input_proj": {
+            "weight": _glorot(k[0], (D_MODEL, 2)),
+            "bias": jnp.zeros(D_MODEL),
+        },
+        "rms1": {"scale": jnp.ones(D_MODEL)},
+        "mha": {
+            "q": _glorot(k[1], (D_MODEL, D_MODEL)),
+            "k": _glorot(k[2], (D_MODEL, D_MODEL)),
+            "v": _glorot(k[3], (D_MODEL, D_MODEL)),
+            "out_w": _glorot(k[4], (D_MODEL, D_MODEL)),
+            "out_b": jnp.zeros(D_MODEL),
+        },
+        "rms2": {"scale": jnp.ones(D_MODEL)},
+        "ff": {
+            "w1": _glorot(k[5], (D_FF, D_MODEL)),
+            "b1": jnp.zeros(D_FF),
+            "w2": _glorot(k[6], (D_MODEL, D_FF)),
+            "b2": jnp.zeros(D_MODEL),
+        },
+        "out": {
+            "w": _glorot(k[7], (1, D_MODEL)),
+            "b": jnp.full((1,), -4.0),
+        },
+    }
+
+
+# ============================================================================
+#  Building blocks
+# ============================================================================
+
+
+def _rms_norm(x, scale):
+    """RMSNorm over last dimension, matching Lux RMSNorm((32,))."""
+    return x / jnp.sqrt(jnp.mean(x**2, axis=-1, keepdims=True) + 1e-6) * scale
+
+
+def _mha(x, p):
+    """Multi-head self-attention (4 heads, no causal mask).
+
+    x: (seq_len, D_MODEL), p: mha param dict.
+    """
+    S = x.shape[0]
+    q = (x @ p["q"].T).reshape(S, N_HEADS, HEAD_DIM).transpose(1, 0, 2)
+    k = (x @ p["k"].T).reshape(S, N_HEADS, HEAD_DIM).transpose(1, 0, 2)
+    v = (x @ p["v"].T).reshape(S, N_HEADS, HEAD_DIM).transpose(1, 0, 2)
+    w = jax.nn.softmax(
+        q @ jnp.swapaxes(k, -2, -1) / jnp.sqrt(jnp.float32(HEAD_DIM)), axis=-1
+    )
+    o = (w @ v).transpose(1, 0, 2).reshape(S, D_MODEL)
+    return o @ p["out_w"].T + p["out_b"]
+
+
+# ============================================================================
+#  Forward pass
+# ============================================================================
+
+
+def policy_forward(params, buf):
+    """Transformer policy forward pass.
+
+    Args:
+        params: parameter pytree from init_params()
+        buf: (N_STEPS, 2) input buffer [observations, actions]
+    Returns:
+        scalar action in [0, ACTION_HI]
+    """
+    # Input projection + positional encoding
+    x = buf @ params["input_proj"]["weight"].T + params["input_proj"]["bias"] + PE
+    # Pre-norm self-attention block
+    x = x + _mha(_rms_norm(x, params["rms1"]["scale"]), params["mha"])
+    # Pre-norm feed-forward block
+    h = _rms_norm(x, params["rms2"]["scale"])
+    ff = jax.nn.gelu(h @ params["ff"]["w1"].T + params["ff"]["b1"])
+    x = x + ff @ params["ff"]["w2"].T + params["ff"]["b2"]
+    # Output: last position -> sigmoid -> scale
+    logit = x[-1] @ params["out"]["w"].T + params["out"]["b"]
+    return ACTION_HI * jax.nn.sigmoid(logit[0])

--- a/benchmark/jax/monod_jax/training.py
+++ b/benchmark/jax/monod_jax/training.py
@@ -1,0 +1,307 @@
+"""Targeted sPCE loss and training loop for Monod bioreactor."""
+
+import functools
+import math
+import time
+
+import jax
+import jax.numpy as jnp
+import optax
+
+from .batched import blocked_batched_spce_loss
+from .model import (
+    N_STEPS,
+    CS0,
+    V0,
+    get_integrator,
+    sample_theta_full,
+    sample_theta_obs,
+)
+from .policy import policy_forward
+
+# ============================================================================
+#  Log-likelihood for a single hypothesis
+# ============================================================================
+
+
+def _compute_ll(observations, designs, theta_dyn, theta_obs, substep_loop="unrolled"):
+    """Total log-likelihood of observations under one parameter hypothesis."""
+    integrate_fn = get_integrator(substep_loop)
+    u0 = jnp.array([CS0, theta_obs[1], V0])
+    sigma_sq = theta_obs[0] ** 2
+
+    def step_fn(carry, x):
+        u, ll = carry
+        obs, design = x
+        u = integrate_fn(u, theta_dyn, design)
+        residual = obs - u[0]
+        ll = ll - 0.5 * (residual**2 / sigma_sq + jnp.log(sigma_sq))
+        return (u, ll), None
+
+    (_, ll_total), _ = jax.lax.scan(step_fn, (u0, 0.0), (observations, designs))
+    return ll_total
+
+
+def _compute_ll_batch(
+    observations, designs, theta_dyn_batch, theta_obs_batch, substep_loop="unrolled"
+):
+    """Vectorized `_compute_ll` over hypotheses."""
+    return jax.vmap(
+        lambda theta_dyn, theta_obs: _compute_ll(
+            observations, designs, theta_dyn, theta_obs, substep_loop
+        )
+    )(theta_dyn_batch, theta_obs_batch)
+
+# ============================================================================
+#  Single-episode sPCE loss (vmapped over B outside)
+# ============================================================================
+
+
+def single_episode_loss(params, key, L, M, substep_loop="unrolled"):
+    """Targeted sPCE loss for ONE episode.
+
+    The batch (B) dimension is handled by an outer jax.vmap.
+
+    Args:
+        params: policy parameter pytree
+        key: PRNG key for this episode
+        L: number of contrastive samples (denominator has L+1 including true)
+        M: number of nuisance samples for numerator
+    Returns:
+        scalar loss
+    """
+    integrate_fn = get_integrator(substep_loop)
+    k_theta, k_obs_numer, k_noise = jax.random.split(key, 3)
+
+    # --- Sample parameters ---
+    n_denom = L + 1
+    theta_full = sample_theta_full(k_theta, n_denom)  # (n_denom, 4)
+
+    # True parameters (first sample)
+    theta_dyn_true = theta_full[0, :2]  # (2,) [mu_max, K_s]
+    sigma_true = theta_full[0, 2]  # scalar noise std
+    Cx0_true = theta_full[0, 3]  # scalar initial biomass
+
+    # Pre-sample observation noise
+    epsilon = jax.random.normal(k_noise, (N_STEPS,))
+
+    # --- Adaptive policy loop ---
+    u0 = jnp.array([CS0, Cx0_true, V0])
+    input_buffer0 = jnp.zeros((N_STEPS, 2))
+
+    def adaptive_step(carry, step_idx):
+        u, input_buffer = carry
+        action = policy_forward(params, input_buffer)
+        u = integrate_fn(u, theta_dyn_true, action)
+        y_obs = u[0] + sigma_true * epsilon[step_idx]
+        input_buffer = input_buffer.at[step_idx, 0].set(y_obs)
+        input_buffer = input_buffer.at[step_idx, 1].set(action)
+        return (u, input_buffer), (y_obs, action)
+
+    (_, _), (observations, designs) = jax.lax.scan(
+        adaptive_step, (u0, input_buffer0), jnp.arange(N_STEPS)
+    )
+    # observations: (N_STEPS,), designs: (N_STEPS,)
+
+    # --- Denominator: L+1 hypotheses ---
+    theta_dyn_denom = theta_full[:, :2]  # (n_denom, 2)
+    theta_obs_denom = theta_full[:, 2:]  # (n_denom, 2)
+    ll_denom = _compute_ll_batch(
+        observations, designs, theta_dyn_denom, theta_obs_denom, substep_loop
+    )
+
+    # --- Numerator: M nuisance samples with true dynamics ---
+    theta_obs_numer = sample_theta_obs(k_obs_numer, M)  # (M, 2)
+    theta_dyn_numer = jnp.broadcast_to(theta_dyn_true, (M, 2))  # (M, 2)
+    ll_numer = _compute_ll_batch(
+        observations, designs, theta_dyn_numer, theta_obs_numer, substep_loop
+    )
+
+    # --- Targeted sPCE ---
+    log_num = jax.scipy.special.logsumexp(ll_numer) - jnp.log(jnp.float32(M))
+    log_den = jax.scipy.special.logsumexp(ll_denom) - jnp.log(jnp.float32(n_denom))
+    return -(log_num - log_den)
+
+
+# ============================================================================
+#  Batch loss (vmapped over B)
+# ============================================================================
+
+
+@functools.partial(jax.checkpoint, static_argnums=(2, 3, 4))
+def _episode_loss_remat(params, key, L, M, substep_loop="unrolled"):
+    """Checkpointed single_episode_loss — stores only (key, loss) for backward,
+    recomputes all intermediates. Allows full-vmap over large B."""
+    return single_episode_loss(params, key, L, M, substep_loop)
+
+
+def batch_loss(params, keys, L, M, chunk_size=0, substep_loop="unrolled"):
+    """Mean sPCE loss over B episodes.
+
+    When chunk_size > 0, processes episodes in small vmapped chunks via
+    lax.scan. When chunk_size <= 0, uses full vmap with per-episode
+    checkpointing for memory efficiency.
+
+    Args:
+        params: policy parameter pytree
+        keys: (B,) array of PRNG keys
+        L, M: contrastive / nuisance sample counts (static)
+        chunk_size: vmap width per chunk (0 = full vmap with remat)
+    Returns:
+        scalar mean loss
+    """
+    if chunk_size <= 0 or chunk_size >= keys.shape[0]:
+        # Full vmap with per-episode remat
+        losses = jax.vmap(
+            lambda key: _episode_loss_remat(params, key, L, M, substep_loop)
+        )(keys)
+        return jnp.mean(losses)
+
+    # Chunked: scan over vmapped chunks. No chunk-level checkpoint —
+    # the adaptive_step checkpoint already controls memory per episode.
+    def _chunk_body(params, chunk_keys, L, M):
+        return jax.vmap(
+            lambda key: single_episode_loss(params, key, L, M, substep_loop)
+        )(chunk_keys)
+
+    n = keys.shape[0]
+    n_chunks = n // chunk_size
+    chunked_keys = keys.reshape(n_chunks, chunk_size, *keys.shape[1:])
+
+    def _scan_step(acc, ck):
+        return acc + jnp.sum(_chunk_body(params, ck, L, M)), None
+
+    total, _ = jax.lax.scan(_scan_step, jnp.float32(0.0), chunked_keys)
+    return total / n
+
+
+# ============================================================================
+#  Training loop
+# ============================================================================
+
+
+def train(
+    params,
+    key,
+    *,
+    L,
+    M,
+    B,
+    n_iters=1000,
+    lr_max=0.003,
+    lr_min=1e-5,
+    warmup=50,
+    grad_accum=1,
+    mode="full_batch",
+    chunk_size=128,
+    hypothesis_chunk_size=32,
+    batch_block_size=1024,
+    substep_loop="unrolled",
+    print_every=10,
+):
+    """Train the adaptive policy.
+
+    Args:
+        params: initial parameter pytree
+        key: PRNG key
+        L, M: contrastive / nuisance sample counts
+        B: total batch size (split into grad_accum micro-batches)
+        n_iters: training iterations
+        lr_max, lr_min, warmup: cosine schedule parameters
+        grad_accum: gradient accumulation steps
+        mode: "full_batch" (default) or "legacy_chunked"
+        chunk_size: episode vmap chunk size for legacy mode
+        hypothesis_chunk_size: hypothesis chunk size for full-batch mode
+        batch_block_size: outer batch block size for full-batch mode
+        substep_loop: RK4 substep loop implementation
+        print_every: logging interval
+    Returns:
+        (params, loss_history)
+    """
+    B_micro = B // grad_accum
+
+    # Cosine LR with warmup (matches common_core.jl:53-59)
+    schedule = optax.warmup_cosine_decay_schedule(
+        init_value=lr_min,
+        peak_value=lr_max,
+        warmup_steps=warmup,
+        decay_steps=n_iters,
+        end_value=lr_min,
+    )
+    opt = optax.adam(learning_rate=schedule)
+    opt_state = opt.init(params)
+
+    if mode == "full_batch":
+        compiled_chunks = (hypothesis_chunk_size, batch_block_size, substep_loop)
+
+        @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5, 6))
+        def grad_fn(
+            params, key, L, M, hypothesis_chunk_size, batch_block_size, substep_loop
+        ):
+            keys = jax.random.split(key, B_micro)
+            return jax.value_and_grad(blocked_batched_spce_loss)(
+                params,
+                keys,
+                L,
+                M,
+                hypothesis_chunk_size,
+                batch_block_size,
+                substep_loop,
+            )
+    elif mode == "legacy_chunked":
+        compiled_chunks = (chunk_size, substep_loop)
+
+        @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5))
+        def grad_fn(params, key, L, M, chunk_size, substep_loop):
+            keys = jax.random.split(key, B_micro)
+            return jax.value_and_grad(batch_loss)(
+                params, keys, L, M, chunk_size, substep_loop
+            )
+    else:
+        raise ValueError(f"Unsupported mode={mode!r}")
+
+    loss_history = []
+    t_start = time.time()
+
+    for step in range(n_iters):
+        total_loss = 0.0
+        acc_grads = None
+
+        for _ in range(grad_accum):
+            key, sk = jax.random.split(key)
+            if mode == "full_batch":
+                loss, grads = grad_fn(
+                    params,
+                    sk,
+                    L,
+                    M,
+                    compiled_chunks[0],
+                    compiled_chunks[1],
+                    compiled_chunks[2],
+                )
+            else:
+                loss, grads = grad_fn(
+                    params, sk, L, M, compiled_chunks[0], compiled_chunks[1]
+                )
+            total_loss += float(loss)
+            if acc_grads is None:
+                acc_grads = grads
+            else:
+                acc_grads = jax.tree.map(jnp.add, acc_grads, grads)
+
+        avg_grads = jax.tree.map(lambda g: g / grad_accum, acc_grads)
+        updates, opt_state = opt.update(avg_grads, opt_state, params)
+        params = optax.apply_updates(params, updates)
+
+        avg_loss = total_loss / grad_accum
+        loss_history.append(avg_loss)
+
+        if (step + 1) % print_every == 0 or step == 0:
+            elapsed = time.time() - t_start
+            lr_t = float(schedule(step))
+            print(
+                f"Iter: [{step + 1:4d}/{n_iters}]\tLoss: {avg_loss:.8f}\t"
+                f"lr: {lr_t:.6f}\ttime: {elapsed:.1f}s"
+            )
+
+    return params, loss_history

--- a/benchmark/jax/profile_run.py
+++ b/benchmark/jax/profile_run.py
@@ -1,0 +1,165 @@
+"""Profile JAX Monod sPCE gradients for comparison with Reactant."""
+
+import argparse
+import functools
+import os
+import time
+
+import jax
+
+from monod_jax.batched import blocked_batched_spce_loss
+from monod_jax.model import allocate_budget
+from monod_jax.policy import init_params
+from monod_jax.training import batch_loss
+
+
+def main():
+    parser = argparse.ArgumentParser(description="JAX Monod sPCE profiling")
+    parser.add_argument("--B", type=int, default=0, help="Micro-batch size (0=auto)")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=("full-batch", "legacy-chunked"),
+        default="full-batch",
+        help="Execution mode",
+    )
+    parser.add_argument(
+        "--chunk",
+        "--episode-chunk",
+        dest="episode_chunk",
+        type=int,
+        default=64,
+        help="Episode vmap chunk size for legacy-chunked mode (0=full vmap)",
+    )
+    parser.add_argument(
+        "--hyp-chunk",
+        type=int,
+        default=32,
+        help="Hypothesis chunk size for full-batch mode (0=materialize full H)",
+    )
+    parser.add_argument(
+        "--batch-block",
+        type=int,
+        default=1024,
+        help="Outer batch block size for full-batch mode (0=single full-B block)",
+    )
+    parser.add_argument(
+        "--substep-loop",
+        type=str,
+        choices=("unrolled", "scan", "fori"),
+        default="unrolled",
+        help="RK4 substep loop implementation",
+    )
+    parser.add_argument("--budget", type=int, default=6_250_000, help="ODE trajectory budget")
+    parser.add_argument("--B-multiplier", type=int, default=8)
+    parser.add_argument("--n-runs", type=int, default=3, help="Profiled runs")
+    parser.add_argument("--n-warmup", type=int, default=2, help="Warmup runs")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--perfetto", type=str, default=None, help="Directory for Perfetto trace")
+    parser.add_argument("--hlo", action="store_true", help="Dump compiled HLO text")
+    args = parser.parse_args()
+
+    L, M, B_auto = allocate_budget(args.budget, B_multiplier=args.B_multiplier)
+    B = args.B if args.B > 0 else B_auto
+    if args.mode == "legacy-chunked" and args.episode_chunk > 0:
+        B = (B // args.episode_chunk) * args.episode_chunk
+
+    print(f"Device: {jax.devices()[0]}")
+    if args.mode == "full-batch":
+        print(
+            f"B={B}, hyp_chunk={args.hyp_chunk}, "
+            f"batch_block={args.batch_block}, "
+            f"substep_loop={args.substep_loop}, L={L}, M={M}"
+        )
+    else:
+        print(
+            f"B={B}, episode_chunk={args.episode_chunk}, "
+            f"substep_loop={args.substep_loop}, L={L}, M={M}"
+        )
+    print(f"Trajectories per grad step: {B * (L + 2 + M):,}")
+    print()
+
+    key = jax.random.key(args.seed)
+    key, init_key = jax.random.split(key)
+    params = init_params(init_key)
+
+    @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5, 6))
+    def grad_step_full_batch(
+        params, keys, L, M, hyp_chunk_size, batch_block_size, substep_loop
+    ):
+        return jax.value_and_grad(blocked_batched_spce_loss)(
+            params, keys, L, M, hyp_chunk_size, batch_block_size, substep_loop
+        )
+
+    @functools.partial(jax.jit, static_argnums=(2, 3, 4, 5))
+    def grad_step_legacy(params, keys, L, M, episode_chunk_size, substep_loop):
+        return jax.value_and_grad(batch_loss)(
+            params, keys, L, M, episode_chunk_size, substep_loop
+        )
+
+    grad_step = (
+        grad_step_full_batch if args.mode == "full-batch" else grad_step_legacy
+    )
+    mode_args = (
+        (args.hyp_chunk, args.batch_block, args.substep_loop)
+        if args.mode == "full-batch"
+        else (args.episode_chunk, args.substep_loop)
+    )
+
+    if args.hlo:
+        print("Lowering and compiling for HLO inspection...")
+        key, sk = jax.random.split(key)
+        keys = jax.random.split(sk, B)
+        lowered = grad_step.lower(params, keys, L, M, *mode_args)
+        compiled = lowered.compile()
+        hlo = compiled.as_text()
+
+        n_fusion = hlo.count("fusion(")
+        n_while = hlo.count("while(")
+        n_command_buffer = hlo.count("command_buffer")
+        print(
+            f"HLO stats: {n_fusion} fusions, {n_while} while-loops, "
+            f"{n_command_buffer} command_buffers"
+        )
+        print(f"HLO size: {len(hlo):,} chars")
+
+        hlo_path = "/tmp/monod_jax_grad.hlo.txt"
+        with open(hlo_path, "w", encoding="utf-8") as f:
+            f.write(hlo)
+        print(f"Full HLO written to {hlo_path}")
+        return
+
+    print("Compiling...", flush=True)
+    t0 = time.perf_counter()
+    for i in range(args.n_warmup):
+        key, sk = jax.random.split(key)
+        keys = jax.random.split(sk, B)
+        loss, grads = grad_step(params, keys, L, M, *mode_args)
+        jax.block_until_ready(loss)
+        if i == 0:
+            print(
+                f"First call (compile): {time.perf_counter() - t0:.1f}s, "
+                f"loss={float(loss):.6f}"
+            )
+
+    perfetto_dir = args.perfetto or "/tmp/jax_monod_trace"
+    os.makedirs(perfetto_dir, exist_ok=True)
+
+    print(f"\nProfiling {args.n_runs} grad steps -> {perfetto_dir}")
+    jax.profiler.start_trace(perfetto_dir)
+    for i in range(args.n_runs):
+        key, sk = jax.random.split(key)
+        keys = jax.random.split(sk, B)
+        t0 = time.perf_counter()
+        loss, grads = grad_step(params, keys, L, M, *mode_args)
+        jax.block_until_ready(loss)
+        dt = time.perf_counter() - t0
+        print(f"  Run {i+1}: {dt*1000:.1f} ms, loss={float(loss):.6f}")
+    jax.profiler.stop_trace()
+
+    print(f"\nPerfetto trace saved to {perfetto_dir}")
+    print("View at https://ui.perfetto.dev")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/jax/pyproject.toml
+++ b/benchmark/jax/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "monod-jax"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "jax[cuda12]",
+    "optax",
+    "numpy",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["monod_jax"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/benchmark/jax/uv.lock
+++ b/benchmark/jax/uv.lock
@@ -1,0 +1,429 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/4f/d79676ab82f2e42fc3611618139f13a9c4c31d0cff4b486982047679a802/absl_py-2.5.0.tar.gz", hash = "sha256:0c996f25c0490700fadabe6351630f6111534fa0ae252cc6d2014ea3b141135f", size = 118119, upload-time = "2026-07-03T10:57:48.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl", hash = "sha256:0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba", size = 137410, upload-time = "2026-07-03T10:57:46.735Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
+]
+
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/b0/e1d392ee24ecd53caa202194746cb12058befde5882d1f3307922829783f/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6f2d66548ee1ee910a836b5fe3d0ebbe1da04a62d0f468ba4822189036a32b3", size = 169847949, upload-time = "2026-06-17T23:42:44.729Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/326facd192b7dc0731e43b30f5ada5ef235e2a3325a151d94ed3db041536/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:806d1fd29038b6acf5a2b289dd62192abea977ee26aef60ea295b1d28a23acf8", size = 174364763, upload-time = "2026-06-17T23:42:49.931Z" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda12-pjrt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/4a/382ec14e57d774148b079c3d251fc9b9e1ed7f92dd2327823f35e0a968a7/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:767a1482dbf652688403c4e22ff01470e1add13c48f9d817169fd8f7440afce5", size = 8093630, upload-time = "2026-06-17T23:42:57.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/19ee8936b00ca74a12bfaebd4703695cee2407f954a6e4e67cdd7f82b7bf/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:4eb6e8e0992fd9897db2468da33f276ae414ec84dc436804124404430502eeac", size = 8141521, upload-time = "2026-06-17T23:42:58.483Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/a9c4ea148d31843764383b26fd66b38cfedad9a6dbf08db634a23d9312c3/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:69776ac849112f4fc2d6fa616f8772106daff38fcdb825c4e39f47e878f27610", size = 8093605, upload-time = "2026-06-17T23:43:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/92/07/3098ae537e68d76bbc98ed61d53e9856f63f4f1bd64f8aeb4d432dad1290/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:948a988927cb10843b501a215181ccb1daed3fa70531b2f1ae0842fe1c08b05e", size = 8141236, upload-time = "2026-06-17T23:43:01.55Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0c/ff1e1975ef108cb2e45deacf5dea812822efaf3210af075f464abd40399c/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:febd9d3f488d182090758936042ad647a60470923715b48a385bc312cb943c63", size = 8108408, upload-time = "2026-06-17T23:43:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c2/04c70eb73beb4df23f49b72d159ca74ee31cccb1be95cdab7491a5ebd259/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:1f1e20fba0aaa3f28ab0a3273754c8c098fa40b74bf4dac5b76c9f2a70425487", size = 8151184, upload-time = "2026-06-17T23:43:05.106Z" },
+    { url = "https://files.pythonhosted.org/packages/95/34/5d5b2993f6b7bbfe781920671de61036faffa5a8bf3740b4ca23d790b6f9/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:4946ec57ddb795e2da8288ceb1ceddd58c2a204a0f7765af89eae486a1d3ace7", size = 8094107, upload-time = "2026-06-17T23:43:06.546Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ac/85bc07d7a0766c7999f9bdfcf7f7cb2487fd0eb5d6bbe2bd41a3a54cd379/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:0c7a0204155585cc1c4fcb30c66b7f881b38e57e1f0d8e97d48e1654bf0d27f8", size = 8141889, upload-time = "2026-06-17T23:43:08.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7d/9fa25e24b96ab06217e1e3dd311a80f3534076bb1b19d46cbc8cf9aa55b9/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:c26a7dd5e71c9edf203b95480f02ec4ad60c9c7e11e38b7310b1fd1dd03ba116", size = 8108639, upload-time = "2026-06-17T23:43:09.651Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/98fa02ba204f5dc88680128129fbc7cd833d5b5ddae2734af93ef85db853/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:c539b052056e8181082fa2635f17e098b3f625d87da53ba35470a2c13480801d", size = 8151505, upload-time = "2026-06-17T23:43:11.023Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/93/ee9cc8743191544f65d26ab7eeb82d65968fe60905662d1a5554d056654b/jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01", size = 61434612, upload-time = "2026-06-17T23:43:57.808Z" },
+    { url = "https://files.pythonhosted.org/packages/11/06/8cc36021bf74d617c312eeed94c280282bb1bcbb32b63f2a42b10ae41575/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331", size = 81085366, upload-time = "2026-06-17T23:44:01.067Z" },
+    { url = "https://files.pythonhosted.org/packages/48/17/38b718af2353dba7753300871e83fbb64a88a772e12727ae27373ab675ce/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7", size = 85467828, upload-time = "2026-06-17T23:44:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c2/d41d13826ebdfe62e56cd87ba70fab3bb9fcbea4a6c9086739a91667e5bf/jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371", size = 65900139, upload-time = "2026-06-17T23:44:07.476Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/68/eaa4cebe253359196a8e80a33b242959e27d8d2a6ae3d09339f21da2acb8/jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e", size = 61434805, upload-time = "2026-06-17T23:44:10.511Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/4b884ea5962b6beb3c0f93742db54246bbf8b3274e48b0aca47908e454be/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556", size = 81084260, upload-time = "2026-06-17T23:44:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/4ee28c65861605945223145fbcd3c9362ec2255ddf7d917574e205548c82/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644", size = 85467706, upload-time = "2026-06-17T23:44:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/9918b0f77a25a1299818c0610305ca2bea38ed90584f4489b60357e2dd39/jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352", size = 65897894, upload-time = "2026-06-17T23:44:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/70df11da52a8b1a826184cccc05a3fec8aed76058a980021873fba3069cb/jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28", size = 61564746, upload-time = "2026-06-17T23:44:24.421Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/184a648ea5db6c8b1a08fc5784c157b4c557255e009fb56091393df3c6de/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299", size = 81204888, upload-time = "2026-06-17T23:44:27.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/539596a55265711d74147913278bcdc38412980be7d74d9c9d860297c486/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305", size = 85583810, upload-time = "2026-06-17T23:44:30.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/27471ec9f1d04674f6e62de809412371e097aed3eca7d9483e677c54c214/jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4", size = 61446097, upload-time = "2026-06-17T23:44:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c8/941a7f7f37510f51290a5bd1a413aeef977fb8ba8adc0cfe8391233a764c/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093", size = 81096546, upload-time = "2026-06-17T23:44:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/69/77/ac054882c220872512df28d16aeb648fe0e651efbb5be4fd7c4817fd88b0/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d", size = 85472993, upload-time = "2026-06-17T23:44:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808", size = 68376553, upload-time = "2026-06-17T23:44:44.968Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9b/91b00ec74985d29708b50420b4103c1f651c8f1c253d4fcb49d1bbb532cd/jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812", size = 61564620, upload-time = "2026-06-17T23:44:48.217Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/49d2b19c3b3105c30e1d3af2062e82e1977fb239d3dc3cbb583ef676dda7/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d", size = 81206365, upload-time = "2026-06-17T23:44:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/99/006cedf443f4a01f2088651facce79b2105bfb4905bfe9162eb0920a6dfb/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895", size = 85584458, upload-time = "2026-06-17T23:44:55.377Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
+name = "monod-jax"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "jax", extra = ["cuda12"] },
+    { name = "numpy" },
+    { name = "optax" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jax", extras = ["cuda12"] },
+    { name = "numpy" },
+    { name = "optax" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f1/cd42563325fa827f54ff30da05686c747652bdbd4cb5654cea54d7d0ad4f/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a42996943f0cd78ddfd61c8bf59361672a19b63e0491aa22a53d6fe63a3f854a", size = 856490582, upload-time = "2026-07-02T16:21:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/10/13/b8887c869cf2471339a24b60d3c28e761facbb534935f572b61423371abb/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:f424192dd85e7d29f44be18df2dae4c80d32c67a29c0d42f5c283c40cfdf871c", size = 799083985, upload-time = "2026-07-02T16:25:37.467Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.4.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.5.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.10.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/9a/a60b98b629e3b7c4ef6385b08c0e169f2048382c75476f377da54b83a8ca/nvidia_nvshmem_cu12-3.7.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7de83f2aa2b58570b4058543fd3c3e992c19f96571380d46ec9b00e0062c6015", size = 229879072, upload-time = "2026-06-30T19:25:39.671Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a2/d1d065914f1860782171c6bd2e5eabcbe4488c66352b468569a6b69d4bf6/nvidia_nvshmem_cu12-3.7.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:faca8717c321f088d3c17490fbfc682bac214986e80b97e232c5ae94f900c45c", size = 230087166, upload-time = "2026-06-30T19:26:24.652Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optax"
+version = "0.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f9/e3d11ae6f298ee941a0690e353a323d158ba5dedc436e75621c310845c5c/optax-0.2.8.tar.gz", hash = "sha256:5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0", size = 301193, upload-time = "2026-03-20T23:30:05.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl", hash = "sha256:e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4", size = 402960, upload-time = "2026-03-20T23:30:03.886Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]

--- a/benchmark/julia/Manifest.toml
+++ b/benchmark/julia/Manifest.toml
@@ -1,0 +1,1584 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "55c2e926b1e15e910d9c7caa7a5f2f3252972f0c"
+
+[[deps.ADTypes]]
+git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
+uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+version = "1.22.2"
+weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
+
+    [deps.ADTypes.extensions]
+    ADTypesChainRulesCoreExt = "ChainRulesCore"
+    ADTypesConstructionBaseExt = "ConstructionBase"
+    ADTypesEnzymeCoreExt = "EnzymeCore"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.7.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
+
+    [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArrayInterface]]
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "75757da5d9f771ef5909fc84f81d2f9d24127315"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "7.27.0"
+
+    [deps.ArrayInterface.extensions]
+    ArrayInterfaceAMDGPUExt = "AMDGPU"
+    ArrayInterfaceBandedMatricesExt = "BandedMatrices"
+    ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
+    ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceCUDSSExt = ["CUDSS", "CUDA"]
+    ArrayInterfaceChainRulesCoreExt = "ChainRulesCore"
+    ArrayInterfaceChainRulesExt = "ChainRules"
+    ArrayInterfaceFillArraysExt = "FillArrays"
+    ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceMetalExt = "Metal"
+    ArrayInterfaceReverseDiffExt = "ReverseDiff"
+    ArrayInterfaceSparseArraysExt = "SparseArrays"
+    ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
+    ArrayInterfaceTrackerExt = "Tracker"
+
+    [deps.ArrayInterface.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Atomix]]
+deps = ["UnsafeAtomics"]
+git-tree-sha1 = "b8651b2eb5796a386b0398a20b519a6a6150f75c"
+uuid = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
+version = "1.1.3"
+
+    [deps.Atomix.extensions]
+    AtomixCUDAExt = "CUDA"
+    AtomixMetalExt = "Metal"
+    AtomixOpenCLExt = "OpenCL"
+    AtomixoneAPIExt = "oneAPI"
+
+    [deps.Atomix.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
+    oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
+
+[[deps.BFloat16s]]
+deps = ["LinearAlgebra", "Printf", "Random"]
+git-tree-sha1 = "e386db8b4753b42caac75ac81d0a4fe161a68a97"
+uuid = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+version = "0.6.1"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BracketingNonlinearSolve]]
+deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "5c73d9606dcb9cdc392ff231d07d2b3ce6c5a375"
+uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+version = "1.12.3"
+weakdeps = ["ChainRulesCore", "ForwardDiff"]
+
+    [deps.BracketingNonlinearSolve.extensions]
+    BracketingNonlinearSolveChainRulesCoreExt = ["ChainRulesCore", "ForwardDiff"]
+    BracketingNonlinearSolveForwardDiffExt = "ForwardDiff"
+
+[[deps.BufferedStreams]]
+git-tree-sha1 = "6863c5b7fc997eadcabdbaf6c5f201dc30032643"
+uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
+version = "1.2.2"
+
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
+[[deps.CPUSummary]]
+deps = ["CpuId", "IfElse", "PrecompileTools", "Preferences", "Static"]
+git-tree-sha1 = "f3a21d7fc84ba618a779d1ed2fcca2e682865bab"
+uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+version = "0.2.7"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.26.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "eeaad7cef88554c2fa56b5a3f71cfd5cb708c662"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.11"
+
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.1"
+
+[[deps.CommonWorldInvalidations]]
+git-tree-sha1 = "cde75cb34c9ee07b4c37981b0f32378d0dc19ffe"
+uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+version = "1.1.1"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ConcreteStructs]]
+git-tree-sha1 = "23a2ac1ab2a39460d4feecddf09b02e9019d6dd5"
+uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
+version = "0.2.6"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [deps.ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.CpuId]]
+deps = ["Markdown"]
+git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+version = "0.3.1"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DiffEqBase]]
+deps = ["ArrayInterface", "BracketingNonlinearSolve", "ConcreteStructs", "DocStringExtensions", "FastBroadcast", "FastClosures", "FastPower", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
+git-tree-sha1 = "2cb87bdcc515b395b107043e7fa408a325a56eed"
+uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
+version = "7.6.2"
+
+    [deps.DiffEqBase.extensions]
+    DiffEqBaseCUDAExt = "CUDA"
+    DiffEqBaseChainRulesCoreExt = "ChainRulesCore"
+    DiffEqBaseDynamicQuantitiesExt = "DynamicQuantities"
+    DiffEqBaseEnzymeExt = ["ChainRulesCore", "Enzyme"]
+    DiffEqBaseFlexUnitsExt = "FlexUnits"
+    DiffEqBaseForwardDiffExt = ["ForwardDiff"]
+    DiffEqBaseGTPSAExt = "GTPSA"
+    DiffEqBaseGeneralizedGeneratedExt = "GeneralizedGenerated"
+    DiffEqBaseMPIExt = "MPI"
+    DiffEqBaseMeasurementsExt = "Measurements"
+    DiffEqBaseMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    DiffEqBaseMooncakeExt = "Mooncake"
+    DiffEqBaseReverseDiffExt = "ReverseDiff"
+    DiffEqBaseSparseArraysExt = "SparseArrays"
+    DiffEqBaseTrackerExt = "Tracker"
+    DiffEqBaseUnitfulExt = "Unitful"
+
+    [deps.DiffEqBase.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+    DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    FlexUnits = "76e01b6b-c995-4ce6-8559-91e72a3d4e95"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
+    GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.DiffResults]]
+deps = ["StaticArraysCore"]
+git-tree-sha1 = "782dd5f4561f5d267313f23853baaaa4c52ea621"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.1.0"
+
+[[deps.DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "79a2aca180a85c690c58a020d47b426954b590f8"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.16.0"
+
+[[deps.DifferentiationInterface]]
+deps = ["ADTypes", "LinearAlgebra"]
+git-tree-sha1 = "dbd46a5cd0e79a97438b0ebbec42e744e8f436fe"
+uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+version = "0.7.20"
+
+    [deps.DifferentiationInterface.extensions]
+    DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
+    DifferentiationInterfaceDiffractorExt = "Diffractor"
+    DifferentiationInterfaceEnzymeExt = ["EnzymeCore", "Enzyme"]
+    DifferentiationInterfaceFastDifferentiationExt = "FastDifferentiation"
+    DifferentiationInterfaceFiniteDiffExt = "FiniteDiff"
+    DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
+    DifferentiationInterfaceForwardDiffExt = ["ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceGPUArraysCoreExt = ["GPUArraysCore", "Adapt"]
+    DifferentiationInterfaceGTPSAExt = "GTPSA"
+    DifferentiationInterfaceHyperHessiansExt = "HyperHessians"
+    DifferentiationInterfaceMooncakeExt = "Mooncake"
+    DifferentiationInterfacePolyesterForwardDiffExt = ["PolyesterForwardDiff", "ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
+    DifferentiationInterfaceSparseArraysExt = "SparseArrays"
+    DifferentiationInterfaceSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DifferentiationInterfaceSparseMatrixColoringsExt = "SparseMatrixColorings"
+    DifferentiationInterfaceStaticArraysExt = "StaticArrays"
+    DifferentiationInterfaceSymbolicsExt = "Symbolics"
+    DifferentiationInterfaceTrackerExt = "Tracker"
+    DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
+
+    [deps.DifferentiationInterface.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+    Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
+    FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+    FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
+    HyperHessians = "06b494a0-c8e0-40cc-ad32-d99506a00a6c"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.DispatchDoctor]]
+deps = ["MacroTools", "Preferences"]
+git-tree-sha1 = "42cd00edaac86f941815fe557c1d01e11913e07c"
+uuid = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
+version = "0.4.28"
+weakdeps = ["ChainRulesCore", "EnzymeCore"]
+
+    [deps.DispatchDoctor.extensions]
+    DispatchDoctorChainRulesCoreExt = "ChainRulesCore"
+    DispatchDoctorEnzymeCoreExt = "EnzymeCore"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.EnumX]]
+git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.7"
+
+[[deps.Enzyme]]
+deps = ["CEnum", "EnzymeCore", "Enzyme_jll", "GPUCompiler", "InteractiveUtils", "LLVM", "Libdl", "LinearAlgebra", "ObjectFile", "PrecompileTools", "Preferences", "Printf", "Random", "SparseArrays"]
+git-tree-sha1 = "5cd3db843fedb95aa30880f3c2eb392084977d9e"
+uuid = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+version = "0.13.184"
+weakdeps = ["ADTypes", "BFloat16s", "ChainRulesCore", "GPUArraysCore", "LogExpFunctions", "SpecialFunctions", "StaticArrays"]
+
+    [deps.Enzyme.extensions]
+    EnzymeBFloat16sExt = "BFloat16s"
+    EnzymeChainRulesCoreExt = "ChainRulesCore"
+    EnzymeGPUArraysCoreExt = "GPUArraysCore"
+    EnzymeLogExpFunctionsExt = "LogExpFunctions"
+    EnzymeSpecialFunctionsExt = "SpecialFunctions"
+    EnzymeStaticArraysExt = "StaticArrays"
+
+[[deps.EnzymeCore]]
+git-tree-sha1 = "971d7831cc85f43bc9f51d615a3f7f21270c2f1d"
+uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
+version = "0.8.21"
+weakdeps = ["Adapt", "ChainRulesCore"]
+
+    [deps.EnzymeCore.extensions]
+    AdaptExt = "Adapt"
+    EnzymeCoreChainRulesCoreExt = "ChainRulesCore"
+
+[[deps.Enzyme_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "6ef5790b091d4d3a05164771dde619db07518883"
+uuid = "7cc45869-7501-5eee-bdea-0790c847d4ef"
+version = "0.0.282+0"
+
+[[deps.ExprTools]]
+git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.10"
+
+[[deps.ExpressionExplorer]]
+git-tree-sha1 = "5f1c005ed214356bbe41d442cc1ccd416e510b7e"
+uuid = "21656369-7473-754a-2065-74616d696c43"
+version = "1.1.4"
+
+[[deps.FastBroadcast]]
+deps = ["ArrayInterface", "LinearAlgebra"]
+git-tree-sha1 = "52216cc6b2e5b11ac6623ff2398ac00faf1c6e42"
+uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+version = "1.3.4"
+
+    [deps.FastBroadcast.extensions]
+    FastBroadcastPolyesterExt = "Polyester"
+    FastBroadcastStaticExt = "Static"
+
+    [deps.FastBroadcast.weakdeps]
+    Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+    Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+
+[[deps.FastClosures]]
+git-tree-sha1 = "acebe244d53ee1b461970f8910c235b259e772ef"
+uuid = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
+version = "0.3.2"
+
+[[deps.FastPower]]
+git-tree-sha1 = "33a6dfb7ad41394b15e90c10c216181dba06cf15"
+uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
+version = "1.3.4"
+
+    [deps.FastPower.extensions]
+    FastPowerEnzymeExt = "Enzyme"
+    FastPowerForwardDiffExt = "ForwardDiff"
+    FastPowerMeasurementsExt = "Measurements"
+    FastPowerMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    FastPowerMooncakeExt = "Mooncake"
+    FastPowerReverseDiffExt = "ReverseDiff"
+    FastPowerTrackerExt = "Tracker"
+
+    [deps.FastPower.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.FindFirstFunctions]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "acb3ed7a72a4f8736d6f34454306cbbe24e63cb2"
+uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
+version = "3.2.0"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "2c5d0b0e12088cde2cf84afb2784415b1ea3dfee"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "1.4.1"
+weakdeps = ["StaticArrays"]
+
+    [deps.ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
+
+[[deps.FunctionWrappers]]
+git-tree-sha1 = "d62485945ce5ae9c0c48f124a84998d755bae00e"
+uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
+version = "1.1.3"
+
+[[deps.FunctionWrappersWrappers]]
+deps = ["FunctionWrappers", "PrecompileTools", "TruncatedStacktraces"]
+git-tree-sha1 = "70a6ddcf65ee666a6873ba4bf1b02dc721474b38"
+uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
+version = "1.10.1"
+
+    [deps.FunctionWrappersWrappers.extensions]
+    FunctionWrappersWrappersEnzymeExt = ["Enzyme", "EnzymeCore"]
+    FunctionWrappersWrappersMooncakeExt = "Mooncake"
+
+    [deps.FunctionWrappersWrappers.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+
+[[deps.Functors]]
+deps = ["Compat", "ConstructionBase", "LinearAlgebra", "Random"]
+git-tree-sha1 = "60a0339f28a233601cb74468032b5c302d5067de"
+uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+version = "0.5.2"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
+
+[[deps.GPUArraysCore]]
+deps = ["Adapt"]
+git-tree-sha1 = "83cf05ab16a73219e5f6bd1bdfa9848fa24ac627"
+uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
+version = "0.2.0"
+
+[[deps.GPUCompiler]]
+deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "PrecompileTools", "Preferences", "REPL", "Scratch", "Serialization", "TOML", "Tracy", "UUIDs"]
+git-tree-sha1 = "5e54ec63c34bcc878558b173c411b8efe6b08344"
+uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
+version = "1.23.0"
+
+    [deps.GPUCompiler.weakdeps]
+    AMDGPU_LLVM_Backend_jll = "cc5c0156-bd05-5a77-8a68-bb0aafb29019"
+    LLVMDowngrader_jll = "f52de702-fb25-5922-94ba-81dd59b07444"
+    NVPTX_LLVM_Backend_jll = "ef6e0fe3-e6ef-59c0-bde6-4989574699e0"
+
+[[deps.HashArrayMappedTries]]
+git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
+uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
+version = "0.2.0"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+    [deps.InverseFunctions.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.6.1"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.KernelAbstractions]]
+deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
+git-tree-sha1 = "a5b87110fa95d711355af44832497745aa93fb52"
+uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+version = "0.9.42"
+weakdeps = ["EnzymeCore", "LinearAlgebra", "SparseArrays"]
+
+    [deps.KernelAbstractions.extensions]
+    EnzymeExt = "EnzymeCore"
+    LinearAlgebraExt = "LinearAlgebra"
+    SparseArraysExt = "SparseArrays"
+
+[[deps.LLVM]]
+deps = ["CEnum", "LLVMExtra_jll", "Libdl", "PrecompileTools", "Preferences", "Printf", "Unicode"]
+git-tree-sha1 = "f74a9668f02e33399baa5ed3a092b3f7a93f192e"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "9.10.0"
+weakdeps = ["BFloat16s"]
+
+    [deps.LLVM.extensions]
+    BFloat16sExt = "BFloat16s"
+
+[[deps.LLVMExtra_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "70c96f133c78c3cdc06234157144fab3744c6b38"
+uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+version = "0.0.43+1"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "eb62a3deb62fc6d8822c0c4bef73e4412419c5d8"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "18.1.8+0"
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.4.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.LibTracyClient_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d4e20500d210247322901841d4eafc7a0c52642d"
+uuid = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
+version = "0.13.1+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "1.0.1"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.Lux]]
+deps = ["ADTypes", "Adapt", "ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DiffResults", "DispatchDoctor", "EnzymeCore", "FastClosures", "ForwardDiff", "Functors", "GPUArraysCore", "LinearAlgebra", "LuxCore", "LuxLib", "MLDataDevices", "MacroTools", "Markdown", "NNlib", "Optimisers", "PrecompileTools", "Preferences", "Random", "ReactantCore", "Reexport", "SciMLPublic", "Setfield", "Static", "StaticArraysCore", "Statistics", "UUIDs", "WeightInitializers"]
+git-tree-sha1 = "b7654d9b1144792d7fa165add2e07434329e3193"
+uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
+version = "1.31.4"
+
+    [deps.Lux.extensions]
+    ComponentArraysExt = "ComponentArrays"
+    EnzymeExt = "Enzyme"
+    FluxExt = "Flux"
+    GPUArraysExt = "GPUArrays"
+    LossFunctionsExt = "LossFunctions"
+    MLUtilsExt = "MLUtils"
+    MPIExt = "MPI"
+    MPINCCLExt = ["CUDA", "MPI", "NCCL"]
+    MooncakeExt = "Mooncake"
+    ReactantExt = ["Enzyme", "Reactant"]
+    ReverseDiffExt = ["FunctionWrappers", "ReverseDiff"]
+    SimpleChainsExt = "SimpleChains"
+    TrackerExt = "Tracker"
+    ZygoteExt = "Zygote"
+
+    [deps.Lux.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+    FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
+    GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+    LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
+    MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    NCCL = "3fe64909-d7a1-4096-9b7d-7a0f12cf0f6b"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SimpleChains = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.LuxCore]]
+deps = ["DispatchDoctor", "Random", "SciMLPublic"]
+git-tree-sha1 = "9455b1e829d8dacad236143869be70b7fdb826b8"
+uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
+version = "1.5.3"
+
+    [deps.LuxCore.extensions]
+    ArrayInterfaceReverseDiffExt = ["ArrayInterface", "ReverseDiff"]
+    ArrayInterfaceTrackerExt = ["ArrayInterface", "Tracker"]
+    ChainRulesCoreExt = "ChainRulesCore"
+    EnzymeCoreExt = "EnzymeCore"
+    FluxExt = "Flux"
+    FunctorsExt = "Functors"
+    MLDataDevicesExt = ["Adapt", "MLDataDevices"]
+    ReactantExt = "Reactant"
+    SetfieldExt = "Setfield"
+
+    [deps.LuxCore.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+    Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
+    MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.LuxLib]]
+deps = ["ArrayInterface", "CPUSummary", "ChainRulesCore", "DispatchDoctor", "EnzymeCore", "FastClosures", "Functors", "KernelAbstractions", "LinearAlgebra", "LuxCore", "MLDataDevices", "Markdown", "NNlib", "Preferences", "Random", "Reexport", "SciMLPublic", "Static", "StaticArraysCore", "Statistics", "UUIDs"]
+git-tree-sha1 = "6a6453d556f7bc3870d797657636b1ad5f45fd27"
+uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
+version = "1.15.9"
+
+    [deps.LuxLib.extensions]
+    AppleAccelerateExt = "AppleAccelerate"
+    BLISBLASExt = "BLISBLAS"
+    CUDAExt = "CUDA"
+    CUDAForwardDiffExt = ["CUDA", "ForwardDiff"]
+    EnzymeExt = "Enzyme"
+    ForwardDiffExt = "ForwardDiff"
+    LoopVectorizationExt = ["LoopVectorization", "Polyester"]
+    MKLExt = "MKL"
+    OctavianExt = ["Octavian", "LoopVectorization"]
+    OneHotArraysExt = ["OneHotArrays"]
+    ReactantExt = ["Reactant", "ReactantCore"]
+    ReverseDiffExt = "ReverseDiff"
+    SLEEFPiratesExt = "SLEEFPirates"
+    TrackerAMDGPUExt = ["AMDGPU", "Tracker"]
+    TrackerExt = "Tracker"
+    cuDNNExt = ["CUDA", "cuDNN"]
+
+    [deps.LuxLib.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    AppleAccelerate = "13e28ba4-7ad8-5781-acae-3021b1ed3924"
+    BLISBLAS = "6f275bd8-fec0-4d39-945b-7e95a765fa1e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+    MKL = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
+    Octavian = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
+    OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
+    Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+    ReactantCore = "a3311ec8-5e00-46d5-b541-4f83e724a433"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+
+[[deps.MLDataDevices]]
+deps = ["Adapt", "Functors", "Preferences", "Random", "SciMLPublic"]
+git-tree-sha1 = "29b00f22be6fd821a214760f0224329f21998a05"
+uuid = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
+version = "1.17.10"
+
+    [deps.MLDataDevices.extensions]
+    AMDGPUExt = "AMDGPU"
+    CUDAExt = "CUDA"
+    ChainRulesCoreExt = "ChainRulesCore"
+    ChainRulesExt = "ChainRules"
+    ComponentArraysExt = "ComponentArrays"
+    FillArraysExt = "FillArrays"
+    GPUArraysSparseArraysExt = ["GPUArrays", "SparseArrays"]
+    MLUtilsExt = "MLUtils"
+    MetalExt = ["GPUArrays", "Metal"]
+    OneHotArraysExt = "OneHotArrays"
+    OpenCLExt = ["GPUArrays", "OpenCL"]
+    ReactantExt = "Reactant"
+    RecursiveArrayToolsExt = "RecursiveArrayTools"
+    ReverseDiffExt = "ReverseDiff"
+    SparseArraysExt = "SparseArrays"
+    TrackerExt = "Tracker"
+    ZygoteExt = "Zygote"
+    cuDNNExt = ["CUDA", "cuDNN"]
+    oneAPIExt = ["GPUArrays", "oneAPI"]
+
+    [deps.MLDataDevices.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+    MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
+    OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+    RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+    cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+    oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MaybeInplace]]
+deps = ["ArrayInterface", "LinearAlgebra", "MacroTools"]
+git-tree-sha1 = "ff492a386f370c79f73232c276a1729f5e841b78"
+uuid = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
+version = "0.1.6"
+weakdeps = ["SparseArrays"]
+
+    [deps.MaybeInplace.extensions]
+    MaybeInplaceSparseArraysExt = "SparseArrays"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.MuladdMacro]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+version = "0.2.6"
+
+[[deps.NNlib]]
+deps = ["Adapt", "Atomix", "ChainRulesCore", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "Random", "ScopedValues", "Statistics"]
+git-tree-sha1 = "446a44652d12ea0a70cbb6f7a9a00ca314ad784a"
+uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.9.38"
+
+    [deps.NNlib.extensions]
+    NNlibAMDGPUExt = "AMDGPU"
+    NNlibCUDACUDNNExt = ["CUDA", "cuDNN"]
+    NNlibCUDAExt = "CUDA"
+    NNlibEnzymeCoreCUDNNExt = ["EnzymeCore", "CUDA", "cuDNN"]
+    NNlibEnzymeCoreExt = "EnzymeCore"
+    NNlibFFTWExt = "FFTW"
+    NNlibForwardDiffExt = "ForwardDiff"
+    NNlibMetalExt = "Metal"
+    NNlibMooncakeCUDAExt = ["Mooncake", "CUDA"]
+    NNlibSpecialFunctionsExt = "SpecialFunctions"
+
+    [deps.NNlib.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+    cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "dbd2e8cd2c1c27f0b584f6661b4309609c5a685e"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.1.4"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.NonlinearSolveBase]]
+deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnzymeCore", "FastClosures", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "LogExpFunctions", "Markdown", "MaybeInplace", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecursiveArrayTools", "SciMLBase", "SciMLJacobianOperators", "SciMLLogging", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
+git-tree-sha1 = "23b0da309f3a24d22d32b80b44ad414011beabfb"
+uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+version = "2.34.1"
+
+    [deps.NonlinearSolveBase.extensions]
+    NonlinearSolveBaseBandedMatricesExt = "BandedMatrices"
+    NonlinearSolveBaseChainRulesCoreExt = "ChainRulesCore"
+    NonlinearSolveBaseEnzymeExt = ["ChainRulesCore", "Enzyme"]
+    NonlinearSolveBaseForwardDiffExt = "ForwardDiff"
+    NonlinearSolveBaseLineSearchExt = "LineSearch"
+    NonlinearSolveBaseLinearSolveExt = "LinearSolve"
+    NonlinearSolveBaseMooncakeExt = "Mooncake"
+    NonlinearSolveBaseReverseDiffExt = "ReverseDiff"
+    NonlinearSolveBaseSparseArraysExt = "SparseArrays"
+    NonlinearSolveBaseSparseMatrixColoringsExt = "SparseMatrixColorings"
+    NonlinearSolveBaseTrackerExt = "Tracker"
+
+    [deps.NonlinearSolveBase.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    LineSearch = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
+    LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.ObjectFile]]
+deps = ["Reexport", "StructIO"]
+git-tree-sha1 = "23c4d109603f7a7bfe888c1f63c5ab7be6183d0b"
+uuid = "d8793406-e978-5875-9003-1fc021f44a92"
+version = "0.5.1"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.Optimisers]]
+deps = ["ChainRulesCore", "ConstructionBase", "Functors", "LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "36b5d2b9dd06290cd65fcf5bdbc3a551ed133af5"
+uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
+version = "0.4.7"
+weakdeps = ["Adapt", "EnzymeCore", "Reactant"]
+
+    [deps.Optimisers.extensions]
+    OptimisersAdaptExt = ["Adapt"]
+    OptimisersEnzymeCoreExt = "EnzymeCore"
+    OptimisersReactantExt = "Reactant"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "05f45c2e0de6259db764adbfd2f1dc6d3f8de13c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "2.0.1"
+
+[[deps.Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "0ed04c372da78ff5b98e35e3bd4f4ca9931299cc"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.13.1"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.6"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PreallocationTools]]
+deps = ["Adapt", "ArrayInterface", "PrecompileTools"]
+git-tree-sha1 = "920abd8738c02528d1078885e07bbd57939fc949"
+uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
+version = "1.3.0"
+
+    [deps.PreallocationTools.extensions]
+    PreallocationToolsEnzymeCoreExt = "EnzymeCore"
+    PreallocationToolsForwardDiffExt = "ForwardDiff"
+    PreallocationToolsReverseDiffExt = "ReverseDiff"
+    PreallocationToolsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+
+    [deps.PreallocationTools.weakdeps]
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "ebf455bb866ee6737030e3d3816bb6a0683c4325"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "3.4.0"
+
+    [deps.PrettyTables.extensions]
+    PrettyTablesExcelExt = "XLSX"
+    PrettyTablesTypstryExt = "Typstry"
+
+    [deps.PrettyTables.weakdeps]
+    Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
+    XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProtoBuf]]
+deps = ["BufferedStreams", "EnumX", "TOML"]
+git-tree-sha1 = "da18083a52d9d57bbe6dadaacad39731e5f7be39"
+uuid = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
+version = "1.3.0"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.Reactant]]
+deps = ["Adapt", "BFloat16s", "CEnum", "Crayons", "Downloads", "EnumX", "Enzyme", "EnzymeCore", "FileWatching", "Functors", "GPUArraysCore", "GPUCompiler", "JSON", "LLVM", "LLVMOpenMP_jll", "Libdl", "LinearAlgebra", "OrderedCollections", "PrecompileTools", "Preferences", "PrettyTables", "ProtoBuf", "Random", "ReactantCore", "Reactant_jll", "ScopedValues", "Scratch", "Serialization", "Setfield", "Sockets", "StableRNGs", "StructUtils", "StyledStrings", "UUIDs", "p7zip_jll"]
+git-tree-sha1 = "9b8c3a7954730b67c450cef2400ea9c1cf6144ca"
+uuid = "3c362404-f566-11ee-1572-e11a4b42c853"
+version = "0.2.273"
+
+    [deps.Reactant.extensions]
+    ReactantAbstractFFTsExt = "AbstractFFTs"
+    ReactantArrayInterfaceExt = "ArrayInterface"
+    ReactantCUDAExt = ["CUDA", "Enzyme", "GPUCompiler", "KernelAbstractions", "LLVM", "Printf"]
+    ReactantDLFP8TypesExt = "DLFP8Types"
+    ReactantDatesExt = "Dates"
+    ReactantFFTWExt = ["FFTW", "AbstractFFTs", "LinearAlgebra"]
+    ReactantFillArraysExt = "FillArrays"
+    ReactantFloat8sExt = "Float8s"
+    ReactantKernelAbstractionsExt = "KernelAbstractions"
+    ReactantLogExpFunctionsExt = ["IrrationalConstants", "LogExpFunctions"]
+    ReactantMCMCDiagnosticToolsExt = ["MCMCDiagnosticTools", "Statistics"]
+    ReactantMPIExt = "MPI"
+    ReactantNNlibExt = ["NNlib", "Statistics"]
+    ReactantNPZExt = "NPZ"
+    ReactantOffsetArraysExt = "OffsetArrays"
+    ReactantOneHotArraysExt = "OneHotArrays"
+    ReactantPythonCallExt = "PythonCall"
+    ReactantRandom123Ext = "Random123"
+    ReactantSparseArraysExt = "SparseArrays"
+    ReactantSpecialFunctionsExt = "SpecialFunctions"
+    ReactantStaticArraysExt = "StaticArrays"
+    ReactantStaticExt = "Static"
+    ReactantStatisticsExt = "Statistics"
+    ReactantStructArraysExt = "StructArrays"
+    ReactantTensorOperationsExt = "TensorOperations"
+    ReactantVectorInterfaceExt = "VectorInterface"
+    ReactantYaoBlocksExt = "YaoBlocks"
+    ReactantZygoteExt = "Zygote"
+
+    [deps.Reactant.weakdeps]
+    AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+    ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    DLFP8Types = "f4c16678-4a16-415b-82ef-ed337c5d6c7c"
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    Float8s = "81dfefd7-55b0-40c6-a251-db853704e186"
+    IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+    MCMCDiagnosticTools = "be115224-59cd-429b-ad48-344e309966f0"
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+    NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+    NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
+    OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+    OneHotArrays = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
+    Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+    PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+    Random123 = "74087812-796a-5b5d-8853-05524746bad3"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+    Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
+    VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
+    YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.ReactantCore]]
+deps = ["ExpressionExplorer", "MacroTools"]
+git-tree-sha1 = "9ae01d91c9326873cea17b97ad198befdf231661"
+uuid = "a3311ec8-5e00-46d5-b541-4f83e724a433"
+version = "0.1.21"
+
+[[deps.Reactant_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "3e36010a340bdace904b29c8dfc10c95af66d26e"
+uuid = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
+version = "0.0.394+0"
+
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.RecursiveArrayTools]]
+deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "LinearAlgebra", "PrecompileTools", "RecipesBase", "StaticArraysCore", "SymbolicIndexingInterface"]
+git-tree-sha1 = "7bdf89cbe4f5e1837b6e64adba6065e59b3b9f94"
+uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
+version = "4.3.4"
+
+    [deps.RecursiveArrayTools.extensions]
+    RecursiveArrayToolsCUDAExt = "CUDA"
+    RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
+    RecursiveArrayToolsFastBroadcastPolyesterExt = ["FastBroadcast", "Polyester"]
+    RecursiveArrayToolsForwardDiffExt = "ForwardDiff"
+    RecursiveArrayToolsKernelAbstractionsExt = "KernelAbstractions"
+    RecursiveArrayToolsMeasurementsExt = "Measurements"
+    RecursiveArrayToolsMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    RecursiveArrayToolsMooncakeExt = "Mooncake"
+    RecursiveArrayToolsReverseDiffExt = ["ReverseDiff", "Zygote"]
+    RecursiveArrayToolsSparseArraysExt = ["SparseArrays"]
+    RecursiveArrayToolsStatisticsExt = "Statistics"
+    RecursiveArrayToolsStructArraysExt = "StructArrays"
+    RecursiveArrayToolsTablesExt = ["Tables"]
+    RecursiveArrayToolsTrackerExt = "Tracker"
+    RecursiveArrayToolsZygoteExt = "Zygote"
+
+    [deps.RecursiveArrayTools.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.1"
+
+[[deps.RuntimeGeneratedFunctions]]
+deps = ["ExprTools", "SHA", "Serialization"]
+git-tree-sha1 = "0e3eba2ca347b001baade9fb830623e04da64b38"
+uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+version = "0.5.22"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SciMLBase]]
+deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FindFirstFunctions", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "Random", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLLogging", "SciMLOperators", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
+git-tree-sha1 = "c248f27771416daab4f2e573a956f41467d43821"
+uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+version = "3.36.0"
+
+    [deps.SciMLBase.extensions]
+    SciMLBaseChainRulesCoreExt = "ChainRulesCore"
+    SciMLBaseDifferentiationInterfaceExt = "DifferentiationInterface"
+    SciMLBaseDistributionsExt = "Distributions"
+    SciMLBaseEnzymeExt = "Enzyme"
+    SciMLBaseForwardDiffExt = "ForwardDiff"
+    SciMLBaseFunctionPropertiesExt = "FunctionProperties"
+    SciMLBaseMakieExt = "Makie"
+    SciMLBaseMeasurementsExt = "Measurements"
+    SciMLBaseMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    SciMLBaseMooncakeExt = "Mooncake"
+    SciMLBasePartialFunctionsExt = "PartialFunctions"
+    SciMLBasePyCallExt = "PyCall"
+    SciMLBasePythonCallExt = "PythonCall"
+    SciMLBaseRCallExt = "RCall"
+    SciMLBaseReverseDiffExt = "ReverseDiff"
+    SciMLBaseStaticArraysExt = "StaticArrays"
+    SciMLBaseTrackerExt = "Tracker"
+    SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore"]
+
+    [deps.SciMLBase.weakdeps]
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+    Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    FunctionProperties = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PartialFunctions = "570af359-4316-4cb7-8c74-252c00c2016b"
+    PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+    PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+    RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.SciMLJacobianOperators]]
+deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DifferentiationInterface", "FastClosures", "LinearAlgebra", "SciMLBase", "SciMLOperators"]
+git-tree-sha1 = "32927d7d411cf7318cef1276cfc8fd2edec8ea69"
+uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
+version = "0.1.15"
+
+[[deps.SciMLLogging]]
+deps = ["Logging", "LoggingExtras", "Preferences"]
+git-tree-sha1 = "5a9e890ad708f45cb33d31ef358bc15764dfb544"
+uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
+version = "2.0.3"
+weakdeps = ["Tracy"]
+
+    [deps.SciMLLogging.extensions]
+    SciMLLoggingTracyExt = "Tracy"
+
+[[deps.SciMLOperators]]
+deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra"]
+git-tree-sha1 = "6727e42481434c5e72574e7957c4a97e70ee3c6a"
+uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+version = "1.24.3"
+
+    [deps.SciMLOperators.extensions]
+    SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
+    SciMLOperatorsSparseArraysExt = "SparseArrays"
+    SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
+
+    [deps.SciMLOperators.weakdeps]
+    LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+
+[[deps.SciMLPublic]]
+git-tree-sha1 = "24ff31136f3f991b74fbef71d5c638e2881d29d2"
+uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
+version = "1.2.3"
+
+[[deps.SciMLStructures]]
+deps = ["ArrayInterface", "PrecompileTools"]
+git-tree-sha1 = "14d4ca3d334637233b9f730d2b9e6061e6338122"
+uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
+version = "1.10.3"
+
+[[deps.ScopedValues]]
+deps = ["HashArrayMappedTries", "Logging"]
+git-tree-sha1 = "67a144433c4ce877ee6d1ada69a124d6b1ecf7be"
+uuid = "7e506255-f358-4e82-b7e4-beb19740aa63"
+version = "1.6.2"
+
+[[deps.Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "9b81b8393e50b7d4e6d0a9f14e192294d3b7c109"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.3.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "c5391c6ace3bc430ca630251d02ea9687169ca68"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.2"
+
+[[deps.SimpleDiffEq]]
+deps = ["DiffEqBase", "FastBroadcast", "LinearAlgebra", "MuladdMacro", "Parameters", "RecursiveArrayTools", "Reexport", "SciMLBase", "StaticArrays"]
+git-tree-sha1 = "0818c8dbb8fd83a72b1608163aeb14960753625b"
+uuid = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
+version = "1.16.3"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.0"
+weakdeps = ["ChainRulesCore"]
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+[[deps.StableRNGs]]
+deps = ["Random"]
+git-tree-sha1 = "4f96c596b8c8258cc7d3b19797854d368f243ddc"
+uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
+version = "1.0.4"
+
+[[deps.Static]]
+deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "5ef96deaf82834d64e1456c6a6665ca4188afd48"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "1.4.4"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.18"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StringManipulation]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "d05693d339e37d6ab134c5ab53c29fce5ee5d7d5"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.4.4"
+
+[[deps.StructIO]]
+git-tree-sha1 = "c581be48ae1cbf83e899b14c07a807e1787512cc"
+uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
+version = "0.3.1"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.SymbolicIndexingInterface]]
+deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
+git-tree-sha1 = "73048fd086b7a169bbd7232bf60bfd43240691eb"
+uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
+version = "0.3.51"
+weakdeps = ["PrettyTables"]
+
+    [deps.SymbolicIndexingInterface.extensions]
+    SymbolicIndexingInterfacePrettyTablesExt = "PrettyTables"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.13.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.TimerOutputs]]
+deps = ["ExprTools", "Printf"]
+git-tree-sha1 = "3748bd928e68c7c346b52125cf41fff0de6937d0"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "0.5.29"
+
+    [deps.TimerOutputs.extensions]
+    FlameGraphsExt = "FlameGraphs"
+
+    [deps.TimerOutputs.weakdeps]
+    FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
+
+[[deps.Tracy]]
+deps = ["ExprTools", "LibTracyClient_jll", "Libdl"]
+git-tree-sha1 = "73e3ff50fd3990874c59fef0f35d10644a1487bc"
+uuid = "e689c965-62c8-4b79-b2c5-8359227902fd"
+version = "0.1.6"
+
+    [deps.Tracy.extensions]
+    TracyProfilerExt = "TracyProfiler_jll"
+
+    [deps.Tracy.weakdeps]
+    TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"
+
+[[deps.TruncatedStacktraces]]
+deps = ["InteractiveUtils", "MacroTools", "Preferences"]
+git-tree-sha1 = "ea3e54c2bdde39062abf5a9758a23735558705e1"
+uuid = "781d530d-4396-4725-bb49-402e4bee1e77"
+version = "1.4.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.UnsafeAtomics]]
+git-tree-sha1 = "0f30765c32d66d58e41f4cb5624d4fc8a82ec13b"
+uuid = "013be700-e6cd-48c3-b4a1-df204f14c38f"
+version = "0.3.1"
+weakdeps = ["LLVM"]
+
+    [deps.UnsafeAtomics.extensions]
+    UnsafeAtomicsLLVM = ["LLVM"]
+
+[[deps.WeightInitializers]]
+deps = ["ConcreteStructs", "GPUArraysCore", "LinearAlgebra", "Random", "SpecialFunctions", "Statistics"]
+git-tree-sha1 = "d60c958a009b5a25cf8ea4eb3f9a2cf7352a9c6f"
+uuid = "d49dbf32-c5c2-4618-8acc-27bb2598ef2d"
+version = "1.3.4"
+
+    [deps.WeightInitializers.extensions]
+    AMDGPUExt = "AMDGPU"
+    CUDAExt = "CUDA"
+    ChainRulesCoreExt = "ChainRulesCore"
+    GPUArraysExt = "GPUArrays"
+    ReactantExt = "Reactant"
+
+    [deps.WeightInitializers.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+    Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/benchmark/julia/Project.toml
+++ b/benchmark/julia/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+Reactant = "=0.2.273"
+julia = "1.12"

--- a/benchmark/julia/bench.jl
+++ b/benchmark/julia/bench.jl
@@ -1,0 +1,102 @@
+# ============================================================================
+# Julia / Reactant benchmark: per-train-step time of the targeted sPCE loss.
+#
+# Times a single steady-state `single_train_step!` (loss + reverse-mode gradient
+# via Enzyme, plus a µs-scale Adam update on the ~8.5k policy params). Data prep
+# is OUTSIDE the timed region; the loss scalar is materialized INSIDE to force an
+# XLA/GPU sync so we time the whole compiled program, not an async dispatch.
+#
+# Two integrators, selected with INTEG:
+#   hand : production hand-written RK4 in a `@trace for` (src/common.jl)
+#   sd   : SimpleDiffEq `SimpleRK4` `step!` driven inside a `@trace for`
+# Same model / loss / policy / config for both — the delta is purely the
+# integrator lowering.
+#
+# Env knobs:
+#   INTEG=hand|sd   BACKEND=gpu|cpu   L=255  M=256  BMICRO=512
+#   NWARM=3  NTIME=20  SEED=0
+# Memory (share a contended GPU): set from the shell before launching, e.g.
+#   XLA_REACTANT_GPU_PREALLOCATE=false XLA_REACTANT_GPU_MEM_FRACTION=0.5
+# ============================================================================
+
+include(joinpath(@__DIR__, "monod_model.jl"))
+include(joinpath(@__DIR__, "common.jl"))
+
+using SimpleDiffEq
+using SciMLBase: init, step!
+using Statistics
+
+# --- SimpleDiffEq integrator: SimpleRK4 step! inside a (non-unrolling) @trace for
+_sd_rhs(u, p, t) = dynamics(u, p[1], p[2])
+function integrate_sd(u, θ, d, dt, n_substeps)
+    dt_sub = dt / n_substeps
+    prob  = ODEProblem(_sd_rhs, u, (0.0f0, dt), (θ, d))
+    integ = init(prob, SimpleRK4(); dt = dt_sub)
+    @trace mincut=true track_numbers=false for _ in 1:n_substeps
+        step!(integ)
+    end
+    return integ.u
+end
+
+const INTEG = get(ENV, "INTEG", "hand")
+INTEG == "sd" && (integrate(u, θ, d, dt, n) = integrate_sd(u, θ, d, dt, n))
+
+backend = get(ENV, "BACKEND", "gpu")
+L       = parse(Int, get(ENV, "L", "255"))
+M       = parse(Int, get(ENV, "M", "256"))
+B_micro = parse(Int, get(ENV, "BMICRO", "512"))
+NWARM   = parse(Int, get(ENV, "NWARM", "3"))
+NTIME   = parse(Int, get(ENV, "NTIME", "20"))
+SEED    = parse(Int, get(ENV, "SEED", "0"))
+Reactant.set_default_backend(backend)
+say(a...) = (println(a...); flush(stdout))
+
+rng = Random.MersenneTwister(SEED)
+ps, st = Lux.setup(rng, policy)
+n_params = Lux.parameterlength(policy)
+xdev = reactant_device()
+ps_ra = ps |> xdev; st_ra = st |> xdev
+u0 = make_u0() |> xdev
+ts = Lux.Training.TrainState(policy, ps_ra, st_ra, Optimisers.Adam(1f-3))
+n_denom = L + 1
+prep() = _prepare_batch_default(rng, n_denom, M, B_micro, u0, xdev)
+
+say("="^68)
+say("Julia/Reactant | integrator=$INTEG | backend=$backend")
+say("L=$L  M=$M  B_micro=$B_micro  n_denom=$n_denom  N_STEPS=$N_STEPS  N_SUBSTEPS=$N_SUBSTEPS")
+say("trajectories/step = ", B_micro * (L + 2 + M), "   policy params = ", n_params)
+say("Reactant ", pkgversion(Reactant))
+say("="^68)
+
+# Wrap in a function so `ts` reassignment uses normal local scope.
+function run_bench(ts, prep, NWARM, NTIME)
+    local last_loss = 0.0f0
+    t_compile = @elapsed for i in 1:NWARM
+        data = prep()
+        _, l, _, ts = Lux.Training.single_train_step!(AutoEnzyme(), targeted_spce_loss, data, ts)
+        last_loss = Float32(l)   # force sync
+    end
+    say("warmup ($NWARM steps, incl compile): ", round(t_compile; digits=1), "s  (loss=", last_loss, ")")
+    times = Float64[]
+    for i in 1:NTIME
+        data = prep()                       # data prep OUTSIDE the timed region
+        t = @elapsed begin
+            _, l, _, ts = Lux.Training.single_train_step!(AutoEnzyme(), targeted_spce_loss, data, ts)
+            last_loss = Float32(l)          # materialize → force GPU sync
+        end
+        push!(times, t)
+    end
+    return times, last_loss, t_compile
+end
+
+times, loss, t_compile = run_bench(ts, prep, NWARM, NTIME)
+med = median(times) * 1000
+say("per-step over $NTIME timed iters:")
+say("  median = ", round(med; digits=2), " ms")
+say("  mean   = ", round(mean(times)*1000; digits=2), " ms")
+say("  min    = ", round(minimum(times)*1000; digits=2), " ms")
+say("  max    = ", round(maximum(times)*1000; digits=2), " ms")
+# Machine-parseable summary line for run_all.sh to collect.
+say("RESULT julia integ=$INTEG L=$L M=$M B=$B_micro median_ms=",
+    round(med; digits=2), " compile_s=", round(t_compile; digits=1), " loss=", loss)
+say("DONE")

--- a/benchmark/julia/common.jl
+++ b/benchmark/julia/common.jl
@@ -1,0 +1,184 @@
+ENV["XLA_FLAGS"] = get(ENV, "XLA_FLAGS", "") * " --xla_gpu_deterministic_ops=true"
+
+# ============================================================================
+# Common definitions for DADS experiments.
+#
+# This file is meant to be `include`d AFTER model.jl. It loads:
+#   1. src/common_core.jl (CPU-safe infrastructure)
+#   2. Reactant-dependent pieces: integrate(), targeted_spce_loss(), train_policy()
+#
+# model.jl must define:
+#   Constants: dynamics(), N_STEPS, DT, N_SUBSTEPS, N_PARAMS_DYN,
+#     N_PARAMS_OBS, N_NOISE_CHANNELS, policy network,
+#     budget constants (L_CONTRASTIVE, M_NUISANCE, GRAD_BATCH, GRAD_ACCUM_STEPS)
+#   Sampling: sample_θ_full(), sample_θ_dyn_numer(), sample_θ_N_joint()
+#   Observation model: make_initial_state(), observe_noisy(), log_likelihood_step!()
+#   Initial state: make_u0()
+# ============================================================================
+
+include(joinpath(@__DIR__, "common_core.jl"))
+
+using Lux, Optimisers, Printf
+using Reactant
+using Reactant: @trace
+
+# ============================================================================
+#  Reactant-compiled ODE integrator
+# ============================================================================
+
+function integrate(u, θ, d, dt, n_substeps)
+    dt_sub = dt / n_substeps
+    @trace mincut=true for _ in 1:n_substeps
+        u = rk4_step(u, θ, d, dt_sub)
+    end
+    return u
+end
+
+# ============================================================================
+#  Targeted sPCE Loss — Joint Nuisance Sampling
+# ============================================================================
+
+function targeted_spce_loss(model, ps, st, data)
+    θ_full, θ_obs_numer, θ_dyn_numer, u0, input_buffer, observations, designs, ε, ll_denom, ll_numer = data
+
+    B = size(ε, 3)
+
+    ll_denom .= 0.0f0
+    ll_numer .= 0.0f0
+
+    θ_dyn_true = θ_full[1:N_PARAMS_DYN, 1:1, :]
+    θ_obs_true_3d = θ_full[N_PARAMS_DYN+1:N_PARAMS_DYN+N_PARAMS_OBS, 1:1, :]
+    θ_obs_true = θ_full[N_PARAMS_DYN+1:N_PARAMS_DYN+N_PARAMS_OBS, 1, :]
+
+    u = make_initial_state(u0, θ_dyn_true, θ_obs_true_3d, B)
+
+    for step in 1:N_STEPS
+        action, st = model(input_buffer, ps, st)
+        d = action
+        designs[step, :] .= d[1, :]
+
+        u = integrate(u, θ_dyn_true, d, DT, N_SUBSTEPS)
+
+        y_noisy = observe_noisy(u, θ_obs_true, ε, step)
+
+        observations[step, :] .= y_noisy
+        input_buffer[1, step, :] .= y_noisy
+        input_buffer[2, step, :] .= d[1, :]
+    end
+
+    # DENOMINATOR
+    n_denom = size(θ_full, 2)
+    θ_dyn_denom = θ_full[1:N_PARAMS_DYN, :, :]
+    θ_obs_denom = θ_full[N_PARAMS_DYN+1:N_PARAMS_DYN+N_PARAMS_OBS, :, :]
+
+    u_denom = make_initial_state(u0, θ_dyn_denom, θ_obs_denom, B)
+
+    for step in 1:N_STEPS
+        d_step = designs[step:step, :]
+        u_denom = integrate(u_denom, θ_dyn_denom, d_step, DT, N_SUBSTEPS)
+        log_likelihood_step!(ll_denom, observations[step:step, :], u_denom, θ_obs_denom)
+    end
+
+    # NUMERATOR
+    M_N = size(ll_numer, 1)
+
+    u_numer = make_initial_state(u0, θ_dyn_numer, θ_obs_numer, B)
+
+    for step in 1:N_STEPS
+        d_step = designs[step:step, :]
+        u_numer = integrate(u_numer, θ_dyn_numer, d_step, DT, N_SUBSTEPS)
+        log_likelihood_step!(ll_numer, observations[step:step, :], u_numer, θ_obs_numer)
+    end
+
+    ll_max_num = maximum(ll_numer; dims=1)
+    lse_num = ll_max_num .+ log.(sum(exp.(ll_numer .- ll_max_num); dims=1))
+    log_numerator = lse_num .- log(Float32(M_N))
+
+    ll_max_den = maximum(ll_denom; dims=1)
+    lse_den = ll_max_den .+ log.(sum(exp.(ll_denom .- ll_max_den); dims=1))
+    log_denominator = lse_den .- log(Float32(n_denom))
+
+    loss_per_episode = -(log_numerator .- log_denominator)
+    loss = sum(loss_per_episode) / Float32(B)
+
+    return loss, st, (;)
+end
+
+# ============================================================================
+#  Training
+# ============================================================================
+
+function _prepare_batch_default(rng, n_denom, M, B_micro, u0, xdev)
+    θ_full_cpu = sample_θ_full(rng, n_denom, B_micro)
+    θ_dyn_numer_cpu = sample_θ_dyn_numer(rng, θ_full_cpu[1:N_PARAMS_DYN, 1:1, :], M, B_micro)
+    θ_full = θ_full_cpu |> xdev
+    θ_dyn_numer = θ_dyn_numer_cpu |> xdev
+    θ_obs_numer = sample_θ_N_joint(rng, M, B_micro) |> xdev
+
+    input_buffer = zeros(Float32, 2, N_STEPS, B_micro) |> xdev
+    observations = zeros(Float32, N_STEPS, B_micro) |> xdev
+    designs = zeros(Float32, N_STEPS, B_micro) |> xdev
+    ε = randn(rng, Float32, N_NOISE_CHANNELS, N_STEPS, B_micro) |> xdev
+    ll_denom = zeros(Float32, n_denom, B_micro) |> xdev
+    ll_numer = zeros(Float32, M, B_micro) |> xdev
+
+    return (θ_full, θ_obs_numer, θ_dyn_numer, u0, input_buffer, observations, designs, ε, ll_denom, ll_numer)
+end
+
+function train_policy(model, ps, st, rng;
+    loss_fn = targeted_spce_loss,
+    prepare_batch = _prepare_batch_default,
+    xdev = identity,
+    n_iters = 50,
+    on_iteration = nothing,
+    lr_max = 0.003f0,
+    lr_min = 1f-5,
+    warmup = 50,
+    grad_accum = GRAD_ACCUM_STEPS,
+    grad_batch = GRAD_BATCH,
+    L = L_CONTRASTIVE,
+    M = M_NUISANCE,
+    save_dir = ".",
+)
+    B_micro = grad_batch ÷ grad_accum
+    n_denom = L + 1
+
+    opt = Adam(lr_min)
+    train_state = Lux.Training.TrainState(model, ps, st, opt)
+    loss_history = Float32[]
+
+    u0 = make_u0()
+    u0 = u0 |> xdev
+
+    for iteration in 1:n_iters
+        ga = grad_accum
+        lr_t = cosine_lr(iteration, n_iters, lr_max, lr_min, warmup)
+        Optimisers.adjust!(train_state.optimizer_state; eta = Float32(lr_t / ga))
+
+        total_loss = 0.0f0
+
+        for _k in 1:ga
+            data = prepare_batch(rng, n_denom, M, B_micro, u0, xdev)
+
+            _, loss_k, _, train_state = Lux.Training.single_train_step!(
+                AutoEnzyme(), loss_fn, data, train_state
+            )
+            total_loss += loss_k
+        end
+
+        avg_loss = total_loss / Float32(ga)
+        push!(loss_history, avg_loss)
+
+        if on_iteration !== nothing
+            on_iteration(iteration, avg_loss, loss_history, train_state)
+        end
+
+        if iteration % 10 == 0 || iteration == 1
+            @printf("Iter: [%4d/%4d]\tLoss: %.8f\tlr: %.6f\tga: %d\n", iteration, n_iters, avg_loss, lr_t, ga)
+        end
+    end
+
+    save_results(save_dir, train_state, loss_history)
+
+    return train_state, loss_history
+end

--- a/benchmark/julia/common_core.jl
+++ b/benchmark/julia/common_core.jl
@@ -1,0 +1,123 @@
+# ============================================================================
+# Core definitions for DADS experiments (CPU-safe, no Reactant).
+#
+# This file is meant to be `include`d AFTER model.jl (which defines dynamics(),
+# constants, sampling, and the policy network). It contains generic
+# infrastructure: RK4, CPU integration, positional encoding, training
+# utilities, and I/O.
+#
+# CPU-only scripts include this file directly; GPU scripts include
+# src/common.jl which adds Reactant-dependent pieces.
+# ============================================================================
+
+using Serialization
+
+# ============================================================================
+#  ODE integrator (CPU, calls dynamics() defined in model.jl)
+# ============================================================================
+
+function rk4_step(u, θ, d, dt)
+    k1 = dynamics(u, θ, d)
+    k2 = dynamics(u .+ 0.5f0 * dt .* k1, θ, d)
+    k3 = dynamics(u .+ 0.5f0 * dt .* k2, θ, d)
+    k4 = dynamics(u .+ dt .* k3, θ, d)
+    return u .+ (dt / 6.0f0) .* (k1 .+ 2.0f0 .* k2 .+ 2.0f0 .* k3 .+ k4)
+end
+
+function integrate_cpu(u, θ, d, dt, n_substeps)
+    dt_sub = dt / n_substeps
+    for _ in 1:n_substeps
+        u = rk4_step(u, θ, d, dt_sub)
+    end
+    return u
+end
+
+# ============================================================================
+#  Positional Encoding
+# ============================================================================
+
+function sinusoidal_pe(seq_len::Int)
+    position = reshape(Float32.(0:(seq_len - 1)), 1, seq_len)
+    div_term = exp.(Float32.(0:2:31) .* -(log(1000.0f0) / 32.0f0))
+    angles = div_term * position
+    pe = zeros(Float32, 32, seq_len)
+    pe[1:2:end, :] .= sin.(angles)
+    pe[2:2:end, :] .= cos.(angles[1:16, :])
+    return pe
+end
+
+# ============================================================================
+#  Cosine Learning Rate
+# ============================================================================
+
+function cosine_lr(iter, n_iters, lr_max, lr_min, warmup)
+    if iter <= warmup
+        return lr_min + (lr_max - lr_min) * (iter / warmup)
+    end
+    progress = (iter - warmup) / (n_iters - warmup)
+    return lr_min + 0.5f0 * (lr_max - lr_min) * (1 + cospi(progress))
+end
+
+# ============================================================================
+#  Results I/O
+# ============================================================================
+
+_to_cpu(x) = x
+_to_cpu(x::AbstractArray) = Array(x)
+_to_cpu(x::NamedTuple) = map(_to_cpu, x)
+_to_cpu(x::Tuple) = map(_to_cpu, x)
+
+"""
+    save_results(dir, train_state, loss_history)
+
+Save training checkpoint to `dir/checkpoint.jls` (parameters, states, loss history).
+"""
+function save_results(dir::AbstractString, train_state, loss_history)
+    mkpath(dir)
+    serialize(joinpath(dir, "checkpoint.jls"), Dict(
+        "parameters"   => _to_cpu(train_state.parameters),
+        "states"       => _to_cpu(train_state.states),
+        "loss_history" => loss_history,
+    ))
+    println("Saved results to $dir/")
+end
+
+# ============================================================================
+#  Checkpoint loading
+# ============================================================================
+
+function load_checkpoint_cpu(path::AbstractString)
+    dir = isdir(path) ? path : ((@assert isfile(path) "Checkpoint not found: $path"); dirname(path))
+    ckpt_path = isdir(path) ? joinpath(path, "checkpoint.jls") : path
+    ckpt = open(deserialize, ckpt_path)
+    return ckpt["parameters"], ckpt["states"], dir
+end
+
+# ============================================================================
+#  Static design loading (shared across eval/plot scripts)
+# ============================================================================
+
+"""
+    load_static_designs(results_dir; T=Float32)
+
+Load static designs from `results_dir`, returning `Vector{Pair{String, Vector{T}}}`.
+Handles both new (`design_bim.jls`) and legacy (`bim_std_design.jls`) filenames,
+and both new (`"design"`) and legacy (`"static_design"`) dict keys.
+"""
+function load_static_designs(results_dir::AbstractString; T::Type=Float32)
+    designs = Pair{String, Vector{T}}[]
+    for (name, filename, legacy_filename) in [
+        ("static_std",  "design_bim.jls",  "bim_std_design.jls"),
+        ("static_spce", "design_spce.jls", "spce_static_design.jls"),
+    ]
+        path = joinpath(results_dir, filename)
+        if !isfile(path)
+            path = joinpath(results_dir, legacy_filename)
+        end
+        isfile(path) || continue
+        d = deserialize(path)
+        key = haskey(d, "design") ? "design" : "static_design"
+        push!(designs, name => T.(d[key]))
+    end
+    return designs
+end

--- a/benchmark/julia/monod_model.jl
+++ b/benchmark/julia/monod_model.jl
@@ -1,0 +1,364 @@
+# ============================================================================
+# Monod bioreactor model — dynamics, constants, sampling, policy, BIM.
+#
+# This file must be included BEFORE src/common_core.jl or src/common.jl.
+# It defines everything model-specific that the generic infrastructure needs.
+# ============================================================================
+
+using Lux, Random
+using ForwardDiff
+using LinearAlgebra
+using Optimisers
+using Printf
+using Serialization
+
+# ============================================================================
+#  Monod Bioreactor Dynamics
+# ============================================================================
+
+function dynamics(u, θ, Q_in)
+    C_s = selectdim(u, 1, 1)
+    C_x = selectdim(u, 1, 2)
+    V = selectdim(u, 1, 3)
+    μ_max = selectdim(θ, 1, 1)
+    K_s = selectdim(θ, 1, 2)
+    μ = @. μ_max * C_s / (K_s + C_s)
+    σ = @. μ / 0.777f0
+    du1 = @. -σ * C_x + (Q_in ./ V) * (50.0f0 - C_s)
+    du2 = @. μ * C_x - (Q_in ./ V) * C_x
+    du3 = @. 0.0f0 * V + Q_in
+
+    du = similar(u)
+    selectdim(du, 1, 1) .= du1
+    selectdim(du, 1, 2) .= du2
+    selectdim(du, 1, 3) .= du3
+    return du
+end
+
+# ============================================================================
+#  Experiment Constants
+# ============================================================================
+
+const N_STEPS = 14
+const DT = 1.0f0
+const N_SUBSTEPS = 50
+
+const ACTION_LO = 0.0f0
+const ACTION_HI = 10.0f0
+
+# ============================================================================
+#  Prior Bounds
+# ============================================================================
+
+const μ_max_lo, μ_max_hi = 0.3f0, 0.5f0
+const K_s_lo, K_s_hi = 0.3f0, 0.6f0
+const σ_lo, σ_hi = 0.05f0, 0.15f0       # Nuisance: measurement noise std
+const Cx0_lo, Cx0_hi = 0.10f0, 0.50f0    # Nuisance: initial biomass
+
+# ASCII aliases
+const mu_max_lo, mu_max_hi = μ_max_lo, μ_max_hi
+const sigma_lo, sigma_hi = σ_lo, σ_hi
+
+const N_TARGET = 2
+const N_PARAMS_DYN = N_TARGET
+const N_PARAMS_OBS = 2      # σ, Cx0
+const N_NOISE_CHANNELS = 1  # single additive Gaussian noise
+
+# ============================================================================
+#  Training Budget Allocation
+# ============================================================================
+
+# Inlined from src/utils.jl (avoids the `using Plots` dependency in the test env).
+function allocate_budget(C::Int; lambda_L::Float64=1.0, lambda_M::Float64=1.0,
+                         B_multiplier::Int=1)
+    L_seed = max(1, round(Int, (2*lambda_L*C*B_multiplier)^(1/3)) - 1)
+    M_seed = max(1, round(Int, (2*lambda_M*C*B_multiplier)^(1/3)))
+    w = max(20, L_seed ÷ 3)
+    best_L, best_M, best_B, best_obj = L_seed, M_seed, fld(C, L_seed+2+M_seed), Inf
+    for L in max(1, L_seed-w):(L_seed+w)
+        for M in max(1, M_seed-w):(M_seed+w)
+            B = fld(C, L + 2 + M)
+            B < 1 && break
+            obj = 1.0/(B * B_multiplier) + lambda_L/(L+1)^2 + lambda_M/M^2
+            if obj < best_obj
+                best_obj, best_L, best_M, best_B = obj, L, M, B
+            end
+        end
+    end
+    return (best_L, best_M, best_B)
+end
+
+const ODE_BUDGET_TRAJ = 6_250_000
+const GRAD_ACCUM_STEPS = 8
+const (L_CONTRASTIVE, M_NUISANCE, _B_MICRO) = allocate_budget(ODE_BUDGET_TRAJ; B_multiplier=GRAD_ACCUM_STEPS)
+const GRAD_BATCH = _B_MICRO * GRAD_ACCUM_STEPS
+
+# ============================================================================
+#  Sampling
+# ============================================================================
+
+function sample_θ_full(rng, n_samples)
+    θ = rand(rng, Float32, 4, n_samples)
+    θ[1, :] .= μ_max_lo .+ (μ_max_hi - μ_max_lo) .* θ[1, :]
+    θ[2, :] .= K_s_lo .+ (K_s_hi - K_s_lo) .* θ[2, :]
+    θ[3, :] .= σ_lo .+ (σ_hi - σ_lo) .* θ[3, :]
+    θ[4, :] .= Cx0_lo .+ (Cx0_hi - Cx0_lo) .* θ[4, :]
+    return θ
+end
+
+function sample_θ_full(rng, n_denom::Int, B::Int)
+    θ = rand(rng, Float32, 4, n_denom, B)
+    @views begin
+        θ[1, :, :] .= μ_max_lo .+ (μ_max_hi - μ_max_lo) .* θ[1, :, :]
+        θ[2, :, :] .= K_s_lo .+ (K_s_hi - K_s_lo) .* θ[2, :, :]
+        θ[3, :, :] .= σ_lo .+ (σ_hi - σ_lo) .* θ[3, :, :]
+        θ[4, :, :] .= Cx0_lo .+ (Cx0_hi - Cx0_lo) .* θ[4, :, :]
+    end
+    return θ
+end
+
+function sample_θ_N_joint(rng, M::Int, B::Int)
+    θ_obs = rand(rng, Float32, N_PARAMS_OBS, M, B)
+    @views begin
+        θ_obs[1, :, :] .= σ_lo .+ (σ_hi - σ_lo) .* θ_obs[1, :, :]
+        θ_obs[2, :, :] .= Cx0_lo .+ (Cx0_hi - Cx0_lo) .* θ_obs[2, :, :]
+    end
+    return θ_obs
+end
+
+function sample_θ_dyn_numer(rng, θ_dyn_true, M, B)
+    return repeat(θ_dyn_true, 1, M, 1)  # all dynamics params are target → just repeat
+end
+
+function draw_prior_samples(rng, n::Int)
+    θ = sample_θ_full(rng, n)
+    samples = Vector{Tuple{Vector{Float32}, Float32, Float32}}(undef, n)
+    @inbounds for i in 1:n
+        samples[i] = (Float32[θ[1, i], θ[2, i]], Float32(θ[3, i]), Float32(θ[4, i]))
+    end
+    return samples
+end
+
+# ============================================================================
+#  Initial State
+# ============================================================================
+
+function make_u0()
+    u0 = zeros(Float32, 3, 1, 1)
+    u0[1, 1, 1] = 3.0f0
+    u0[2, 1, 1] = 0.25f0
+    u0[3, 1, 1] = 7.0f0
+    return u0
+end
+
+# ============================================================================
+#  Observation Model Callbacks
+# ============================================================================
+
+function make_initial_state(u0, _θ_dyn, θ_obs, B)
+    n_samples = size(θ_obs, 2)
+    return vcat(
+        repeat(u0[1:1, :, :], 1, n_samples, B),
+        θ_obs[2:2, :, :],
+        repeat(u0[3:3, :, :], 1, n_samples, B),
+    )
+end
+
+function observe_noisy(u, θ_obs_true, ε, step)
+    obs = u[1, 1, :]
+    return obs .+ θ_obs_true[1, :] .* ε[1, step, :]
+end
+
+function log_likelihood_step!(ll, y_broadcast, u_pred, θ_obs)
+    pred_obs = u_pred[1, :, :]
+    σ² = θ_obs[1, :, :] .^ 2
+    residual = y_broadcast .- pred_obs
+    ll .-= 0.5f0 .* (residual .^ 2 ./ σ² .+ log.(σ²))
+    return nothing
+end
+
+# ============================================================================
+#  Policy Network
+# ============================================================================
+
+const policy = @compact(
+    input_proj = Dense(2 => 32),
+    rms1 = RMSNorm((32,)),
+    mha = MultiHeadAttention(32; nheads = 4),
+    rms2 = RMSNorm((32,)),
+    ff = Chain(Dense(32 => 64, gelu), Dense(64 => 32)),
+    output_head = Dense(32 => 1; init_bias=(rng, dims...) -> fill(-4.0f0, dims...)),
+) do x
+    seq_len = size(x, 2)
+    x = input_proj(x)
+    x = x .+ reshape(sinusoidal_pe(seq_len), 32, seq_len, 1)
+    h = rms1(x)
+    attn, _ = mha(h)
+    x = x + attn
+    x = x + ff(rms2(x))
+    @return ACTION_HI .* sigmoid.(output_head(x[:, end, :]))
+end
+
+# ============================================================================
+#  ForwardDiff-compatible trajectory
+# ============================================================================
+
+function substrate_trajectory_diff(params::AbstractVector, design::AbstractVector;
+                                    n_substeps::Int=N_SUBSTEPS)
+    T = promote_type(eltype(params), eltype(design))
+    u = zeros(T, 3, 1)
+    u[1, 1] = T(3.0)
+    u[2, 1] = params[3]    # Cx0
+    u[3, 1] = T(7.0)
+    θ_mat = reshape(T[params[1], params[2]], 2, 1)
+    c_s = Vector{T}(undef, N_STEPS)
+    for step in 1:N_STEPS
+        u = integrate_cpu(u, θ_mat, T(design[step]), T(DT), n_substeps)
+        c_s[step] = u[1, 1]
+    end
+    return c_s
+end
+
+# ============================================================================
+#  Fisher Information Matrix (3x3, for [mu_max, K_s, Cx0])
+# ============================================================================
+
+# Prior precision for uniform priors: 12 / width^2
+const PRIOR_PREC = Float64[
+    12.0 / (Float64(μ_max_hi) - Float64(μ_max_lo))^2,
+    12.0 / (Float64(K_s_hi) - Float64(K_s_lo))^2,
+    12.0 / (Float64(Cx0_hi) - Float64(Cx0_lo))^2,
+]
+
+function fim_matrix(theta_T, sigma, Cx0, design::AbstractVector;
+                     n_substeps::Int=N_SUBSTEPS)
+    params = Float64[Float64(theta_T[1]), Float64(theta_T[2]), Float64(Cx0)]
+    J = ForwardDiff.jacobian(
+        p -> substrate_trajectory_diff(p, design; n_substeps=n_substeps),
+        params
+    )
+    T = eltype(J)
+    σ2 = T(Float64(sigma))^2
+    return (one(T) / σ2) .* (J' * J)
+end
+
+function schur_complement_2x2(B::AbstractMatrix)
+    B_TT = B[1:2, 1:2]
+    B_TN = B[1:2, 3:3]
+    B_NN = B[3, 3]
+    return B_TT - B_TN * B_TN' / B_NN
+end
+
+# ============================================================================
+#  Bayesian D-optimal objectives
+# ============================================================================
+
+function bim_logdet(design::AbstractVector, prior_samples;
+                     n_substeps::Int=N_SUBSTEPS)
+    T = promote_type(Float64, eltype(design))
+    score = zero(T)
+    for (theta_T, sigma, Cx0) in prior_samples
+        F = fim_matrix(theta_T, sigma, Cx0, design; n_substeps=n_substeps)
+        for k in 1:3
+            F[k, k] += T(PRIOR_PREC[k])
+        end
+        score += logdet(Symmetric(schur_complement_2x2(F)))
+    end
+    return score / length(prior_samples)
+end
+
+# ============================================================================
+#  Design optimization helpers
+# ============================================================================
+
+function optimize_design_grad(objective, init::AbstractVector{Float64};
+        n_iters::Int=250, lr_max::Float64=0.003, lr_min::Float64=1e-5,
+        warmup::Int=50, results_dir::Union{String,Nothing}=nothing,
+        prefix::String="bim")
+
+    design = copy(init)
+    opt_state = Optimisers.setup(Adam(lr_min), design)
+
+    best_design = copy(design)
+    best_score = -Inf
+    score_history = Float64[]
+
+    for iter in 1:n_iters
+        g = ForwardDiff.gradient(objective, design)
+        lr = cosine_lr(iter, n_iters, lr_max, lr_min, warmup)
+        Optimisers.adjust!(opt_state; eta = lr)
+        opt_state, design = Optimisers.update!(opt_state, design, -g)
+        clamp!(design, 0.0, 10.0)
+
+        score = objective(design)
+        push!(score_history, score)
+        if score > best_score
+            best_score = score
+            best_design .= design
+        end
+
+        if iter % 25 == 0 || iter == 1 || iter == n_iters
+            @printf("[GRAD] iter %3d/%3d | lr=%.6f | score=%.5f | best=%.5f\n",
+                    iter, n_iters, lr, score, best_score)
+            flush(stdout)
+
+            if results_dir !== nothing && isdefined(Main, :Plots)
+                p = Plots.plot(; xlabel="Iteration", ylabel="BIM logdet",
+                                 title="BIM Optimization ($prefix)", legend=:bottomright)
+                Plots.plot!(p, score_history; label="score", lw=1.5)
+                Plots.savefig(p, joinpath(results_dir, "plot_$(prefix)_loss.png"))
+            end
+        end
+    end
+
+    @printf("[GRAD] best score = %.5f\n", best_score)
+    flush(stdout)
+    return Float32.(best_design), best_score
+end
+
+function optimize_static_design_grad(prior_samples, init::AbstractVector{Float64};
+        n_iters::Int=250, lr_max::Float64=0.003, lr_min::Float64=1e-5,
+        warmup::Int=50, n_substeps::Int=N_SUBSTEPS,
+        results_dir::Union{String,Nothing}=nothing, prefix::String="bim")
+    objective = ξ -> bim_logdet(ξ, prior_samples; n_substeps=n_substeps)
+    return optimize_design_grad(objective, init; n_iters, lr_max, lr_min, warmup,
+                                results_dir, prefix)
+end
+
+function adaptive_mean_design(model, ps_cpu, st_cpu;
+        n_rollouts::Int=1000, seed::Int=0, n_substeps::Int=N_SUBSTEPS)
+    rng = MersenneTwister(seed)
+    avg = zeros(Float64, N_STEPS)
+    for _ in 1:n_rollouts
+        θ = sample_θ_full(rng, 1)
+        d = rollout_adaptive_design_cpu(model, ps_cpu, st_cpu, rng,
+                Float32[θ[1,1], θ[2,1]], Float32(θ[3,1]);
+                Cx0=Float32(θ[4,1]), n_substeps=n_substeps)
+        avg .+= Float64.(d)
+    end
+    return avg ./ n_rollouts
+end
+
+# ============================================================================
+#  Adaptive policy rollout (CPU, Float32)
+# ============================================================================
+
+function rollout_adaptive_design_cpu(model, ps_cpu, st_cpu, rng,
+        theta_T::Vector{Float32}, sigma::Float32;
+        Cx0::Float32=0.25f0, n_substeps::Int=N_SUBSTEPS)
+    u = reshape(Float32[3.0f0, Cx0, 7.0f0], 3, 1)
+    input_buffer = zeros(Float32, 2, N_STEPS, 1)
+    designs = zeros(Float32, N_STEPS)
+    st_local = st_cpu
+    theta_mat = reshape(theta_T, 2, 1)
+    @inbounds for step in 1:N_STEPS
+        action, st_local = model(input_buffer, ps_cpu, st_local)
+        d = clamp(Float32(action[1]), ACTION_LO, ACTION_HI)
+        designs[step] = d
+        u = integrate_cpu(u, theta_mat, d, DT, n_substeps)
+        y_obs = u[1, 1] + sigma * randn(rng, Float32)
+        input_buffer[1, step, 1] = y_obs
+        input_buffer[2, step, 1] = d
+    end
+    return designs
+end

--- a/benchmark/run_all.sh
+++ b/benchmark/run_all.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Fair head-to-head: JAX vs Julia/Reactant on the Monod targeted-sPCE gradient
+# step. Runs every variant SEQUENTIALLY (never concurrently) so neither side is
+# starved of the shared GPU, at a single MATCHED (L, M, B) config, float32,
+# N_STEPS=14, N_SUBSTEPS=50, full materialization (no hypothesis/batch chunking).
+#
+# Both harnesses print a `RESULT ...` line; we grep those into results.txt.
+#
+# Config (override via env): L=255 M=256 B=512 NWARM/NTIME for Julia,
+# N_WARMUP/N_RUNS for JAX.
+#
+# Memory caps assume a contended GPU (~8 GB free of 16). Adjust MEM_FRAC if you
+# have the card to yourself.
+# ============================================================================
+set -euo pipefail
+cd "$(dirname "$0")"
+
+L=${L:-255}
+M=${M:-256}
+B=${B:-512}
+MEM_FRAC=${MEM_FRAC:-0.45}     # fraction of TOTAL GPU memory each process may use
+JULIA_CHANNEL=${JULIA_CHANNEL:-release}
+
+LOGDIR=logs
+mkdir -p "$LOGDIR"
+RESULTS=results.txt
+: > "$RESULTS"
+
+echo "############################################################"
+echo "# Matched config: L=$L  M=$M  B=$B  (float32, N_STEPS=14, N_SUBSTEPS=50)"
+echo "# GPU mem cap per process: ${MEM_FRAC} of total"
+echo "############################################################"
+
+# ---------------------------------------------------------------------------
+# Julia / Reactant : hand-RK4 and SimpleDiffEq, both in a @trace for loop.
+# ---------------------------------------------------------------------------
+for INTEG in hand sd; do
+  echo ">>> Julia/Reactant  integ=$INTEG"
+  log="$LOGDIR/julia_${INTEG}.log"
+  INTEG=$INTEG L=$L M=$M BMICRO=$B BACKEND=gpu \
+    XLA_REACTANT_GPU_PREALLOCATE=false \
+    XLA_REACTANT_GPU_MEM_FRACTION=$MEM_FRAC \
+    julia +"$JULIA_CHANNEL" --startup=no --project=julia julia/bench.jl 2>&1 | tee "$log"
+  grep '^RESULT' "$log" >> "$RESULTS" || true
+done
+
+# ---------------------------------------------------------------------------
+# JAX : scan / fori substep loops (the loop-based analogues of Reactant's
+# @trace for). Full materialization to match Reactant: --hyp-chunk 0 (full
+# hypothesis axis) --batch-block 0 (single block).
+#
+# The package also has a fully-`unrolled` loop, intentionally NOT run here: it
+# has no Reactant counterpart (deep unroll blows up tracing) and does not scale
+# with substep depth. See README.md.
+# ---------------------------------------------------------------------------
+for LOOP in scan fori; do
+  echo ">>> JAX  substep=$LOOP"
+  log="$LOGDIR/jax_${LOOP}.log"
+  XLA_PYTHON_CLIENT_PREALLOCATE=false \
+    XLA_PYTHON_CLIENT_MEM_FRACTION=$MEM_FRAC \
+    uv run --project=jax python jax/benchmark.py \
+      --L "$L" --M "$M" --B "$B" \
+      --mode full-batch --hyp-chunk 0 --batch-block 0 \
+      --substep-loop "$LOOP" 2>&1 | tee "$log"
+  grep '^RESULT' "$log" >> "$RESULTS" || true
+done
+
+echo "############################################################"
+echo "# Collected results ($RESULTS):"
+cat "$RESULTS"
+echo "############################################################"


### PR DESCRIPTION
A fair, matched-config head-to-head of the **targeted sPCE gradient step** — the inner loop of adaptive-experimental-design training — implemented in JAX and in Julia/Reactant. Lives in a self-contained [`benchmark/`](benchmark/) folder.

## What's compared

| implementation | substep loop | source |
|---|---|---|
| Julia hand-RK4 | `@trace for` | production `common.jl` (copied from `src/`) |
| Julia SimpleDiffEq | `@trace for` + `step!` | from `simplediffeq_test/` |
| JAX `scan` | `lax.scan` | `monod_jax` from `3188aaa` |
| JAX `fori` | `lax.fori_loop` | `monod_jax` from `3188aaa` |

Same Monod model, same targeted-sPCE estimator, same ~8.5k-param transformer policy, same `(L,M,B)`, float32.

## Why a new folder / fresh env
`simplediffeq_test/` pins a **dev checkout** of Reactant (`0.2.263`). This folder pins the **latest release** `Reactant = "=0.2.273"`, so it doubles as a check that the production loss compiles/differentiates/trains on a released Reactant.

## Fairness ground rules
- Matched `(L,M,B)` — added `--L/--M` overrides to `benchmark.py` so both run the exact same shape.
- Same timed region (loss + gradient); Julia's extra Adam step on ~8.5k params is µs-negligible.
- Full materialization both sides (JAX `--hyp-chunk 0 --batch-block 0`) — the clean apples-to-apples point.
- Data prep excluded, device sync forced, median of 20 steps after warmup, variants run **sequentially** with a GPU mem cap.
- Fully-unrolled JAX **deliberately excluded**: no Reactant counterpart (deep unroll blows up tracing) and it doesn't scale with substep depth.

## Results (L=255, M=256, B=512, RTX 4080 SUPER, Reactant 0.2.273, jax 0.10.2)

| implementation | substep loop | per-step (median) | compile |
|---|---|---|---|
| Julia / Reactant — SimpleDiffEq | `@trace for` + `step!` | **105.7 ms** | 205 s |
| Julia / Reactant — hand-RK4 | `@trace for` | **113.5 ms** | 200 s |
| JAX | `lax.scan` | 289.0 ms | **2.8 s** |
| JAX | `lax.fori_loop` | 290.1 ms | **2.7 s** |

- **Reactant `@trace for` is ~2.7× faster per step** than JAX's loop path at matched full-materialization.
- **JAX compiles ~70× faster** (~3 s vs ~200 s) — matters for dev iteration, negligible over a multi-hour run.
- **hand-RK4 ≈ SimpleDiffEq** — identical loss to 5 sig figs (−0.71462), ~7% timing; a genuine drop-in.

See [`benchmark/README.md`](benchmark/README.md) for methodology and `benchmark/run_all.sh` to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)